### PR TITLE
ANVGL-3 Updates to Storage/Compute to support AWS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
             <version>${hibernate.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator-annotation-processor</artifactId>
+            <version>4.1.0.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -194,69 +194,43 @@
         </constructor-arg>
     </bean>
 
-    <bean id="cloudStorageService-nectar-melb" class="org.auscope.portal.core.services.cloud.CloudStorageService">
-        <constructor-arg name="endpoint" value="https://keystone.rc.nectar.org.au:5000/v2.0"/>
-        <constructor-arg name="provider" value="swift-keystone"/>
-        <constructor-arg name="accessKey" value="${env.nectar.storage.accesskey}"/>
-        <constructor-arg name="secretKey" value="${env.nectar.storage.secretkey}"/>
-        <constructor-arg name="regionName" value="Melbourne"/>
+    <bean id="cloudStorageService-aws-sydney" class="org.auscope.portal.core.services.cloud.CloudStorageService">
+        <constructor-arg name="provider" value="aws-s3"/>
+        <constructor-arg name="endpoint"><null/></constructor-arg>
+        <constructor-arg name="accessKey" value="${env.aws.s3.accesskey}"/>
+        <constructor-arg name="secretKey" value="${env.aws.s3.secretkey}"/>
+        <constructor-arg name="regionName" value="ap-southeast-2"/>
         <constructor-arg name="relaxHostName" value="false"/>
         <constructor-arg name="stripExpectHeader" value="true"/>
-        <property name="name" value="National eResearch Collaboration Tools and Resources"/>
-        <property name="id" value="nectar-openstack-storage-melb"/>
-        <property name="bucket" value="vgl-portal"/>
-        <property name="authVersion" value="2.0"/>
+        <property name="name" value="Amazon Web Services - S3"/>
+        <property name="id" value="amazon-aws-storage-sydney"/>
+        <property name="bucket" value="anvgl-csiro"/>
     </bean>
 
     <bean id="inetAddress" class="java.net.InetAddress" factory-method="getLocalHost"/>
 
-    <bean id="cloudComputeService-nectar" class="org.auscope.portal.core.services.cloud.CloudComputeService">
-        <constructor-arg name="provider" value="NovaKeystone"/>
-        <constructor-arg name="endpoint" value="https://keystone.rc.nectar.org.au:5000/v2.0"/>
-        <constructor-arg name="accessKey" value="${env.nectar.ec2.accesskey}"/>
-        <constructor-arg name="secretKey" value="${env.nectar.ec2.secretkey}"/>
-        <property name="id" value="nectar-openstack-compute"/>
-        <property name="name" value="National eResearch Collaboration Tools and Resources"/>
-        <property name="groupName" value ="vl-#{inetAddress.hostName.toLowerCase()}"/>
+    <bean id="cloudComputeService-aws" class="org.auscope.portal.core.services.cloud.CloudComputeService">
+        <constructor-arg name="provider" value="AWSEc2"/>
+        <constructor-arg name="endpoint"><null/></constructor-arg>
+        <constructor-arg name="apiVersion"><null/></constructor-arg>
+        <constructor-arg name="accessKey" value="${env.aws.ec2.accesskey}"/>
+        <constructor-arg name="secretKey" value="${env.aws.ec2.secretkey}"/>
+        <constructor-arg name="httpServiceCaller" ref="httpServiceCaller"/>
+        
+        <property name="id" value="aws-ec2-compute"/>
+        <property name="name" value="Amazon Web Services - EC2"/>
+        <property name="keypair" value="developers-anvgl-aws"/>
+        <property name="zone" value="ap-southeast-2"/>
         <property name="availableImages">
             <list>
                 <bean class="org.auscope.portal.server.vegl.VglMachineImage">
-                    <constructor-arg name="imageId" value="Melbourne/07005d01-0dc8-4e2d-9eba-cdc36349a463"/>
+                    <constructor-arg name="imageId" value="ap-southeast-2/ami-0487de67"/>
                     <property name="name" value="escript"/>
                     <property name="description"><value>A Debian (Jessie) machine with escript already installed.</value></property>
-                    <property name="minimumDiskGB" value="10"/>
                     <property name="keywords">
                         <array>
                             <value>escript</value>
-                            <value>centos6</value>
-                        </array>
-                    </property>
-                </bean>
-                <bean class="org.auscope.portal.server.vegl.VglMachineImage">
-                    <constructor-arg name="imageId" value="Melbourne/e4dfe8cc-3b07-41c9-8b53-b82960797769"/>
-                    <property name="name" value="Underworld"/>
-                    <property name="description"><value>A Centos 6 machine with Underworld already installed.</value></property>
-                    <property name="keywords">
-                        <array>
-                            <value>Underworld</value>
-                            <value>centos6</value>
-                        </array>
-                    </property>
-                </bean>
-                <bean class="org.auscope.portal.server.vegl.VglMachineImage">
-                    <constructor-arg name="imageId" value="Melbourne/19121286-6d84-4dba-8e60-fcca85812421"/>                   
-                    <property name="name" value="AEM-Inversion"/>
-                    <property name="description"><value>A Debian 8 machine with AEM Inversion already installed.</value></property>
-                    <property name="minimumDiskGB" value="10"/>
-                    <property name="keywords">
-                        <array>
-                            <value>AEM-Inversion</value>
-                            <value>debian8</value>
-                        </array>
-                    </property>
-                    <property name="permissions">
-                        <array>
-                            <value>ROLE_USER</value>
+                            <value>debian</value>
                         </array>
                     </property>
                 </bean>

--- a/vm/cloud.sh
+++ b/vm/cloud.sh
@@ -39,20 +39,24 @@ then
 fi
 
 #wrapper for aws upload
-if [[ "$STORAGE_TYPE" == "aws" ]]
+if [[ "$STORAGE_TYPE" == aws* ]]
 then
+        export AWS_ACCESS_KEY_ID=$STORAGE_ACCESS_KEY
+        export AWS_SECRET_ACCESS_KEY=$STORAGE_SECRET_KEY
+        export AWS_DEFAULT_REGION=$OS_REGION_NAME
+
         if [[ "$1" == "list" ]]
         then
-                aws list "$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH"
+                aws s3 ls "s3://$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH/" | awk '{print $4}'
         fi
 
         if [[ "$1" == "download" ]]
         then
-                aws get "$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH/$2" "$3"
+                aws s3 cp "s3://$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH/$2" "$3"
         fi
 
         if [[ "$1" == "upload" ]]
         then
-                aws put "$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH/$2" "$3"
+                aws s3 cp "$3" "s3://$STORAGE_BUCKET/$STORAGE_BASE_KEY_PATH/$2"
         fi      
 fi


### PR DESCRIPTION
Adds s3/ec2 versions of the cloudcompute/cloudstorage services. Updates cloud.sh to use the current version of aws CLI

Don't pull this in until the associated PR at portal core has been accepted