### PR TITLE
ANVGL-70 More robust job VM status checking

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -747,6 +747,12 @@ public class JobBuilderController extends BaseCloudController {
         } catch (PortalServiceException e) {
             errorDescription = e.getMessage();
             errorCorrection = e.getErrorCorrection();
+
+            //These are our "STS specific" overrides to some error messages (not an ideal solution but I don't want to have to overhaul everything just to tweak a string).
+            if (errorDescription.equals("Storage credentials are not valid.")) {
+                errorDescription = "Unable to upload job script and/or input files";
+                errorCorrection = "The most likely cause is that your user profile ARN's have been misconfigured.";
+            }
         } catch (IOException e) {
             logger.error("Job bootstrap creation failed.", e);
             errorDescription = "There was a problem creating startup script.";

--- a/src/main/java/org/auscope/portal/server/web/service/monitor/VGLJobStatusChangeHandler.java
+++ b/src/main/java/org/auscope/portal/server/web/service/monitor/VGLJobStatusChangeHandler.java
@@ -46,7 +46,11 @@ public class VGLJobStatusChangeHandler implements JobStatusChangeListener {
         if (!newStatus.equals(JobBuilderController.STATUS_UNSUBMITTED)) {
             VEGLJob vglJob = (VEGLJob)job;
             vglJob.setProcessDate(new Date());
-            this.setProcessDuration(vglJob,newStatus);
+            try {
+                this.setProcessDuration(vglJob,newStatus);
+            } catch (Throwable ex) {
+                LOG.debug("Unable to set process duration for" + job, ex);
+            }
             vglJob.setStatus(newStatus);
             jobManager.saveJob(vglJob);
             jobManager.createJobAuditTrail(oldStatus, vglJob, "Job status updated.");

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-cloudformation.json.tpl
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-cloudformation.json.tpl
@@ -230,6 +230,7 @@
                 "ec2:CreateTags",
                 "ec2:DeleteTags",
                 "ec2:GetConsoleOutput",
+                "ec2:DescribeInstanceStatus",
                 "ec2:ModifyInstanceAttribute"
               ],
               "Resource": [


### PR DESCRIPTION
Don't pull this until https://github.com/AuScope/portal-core/pull/143 is in (it won't compile)

 I've improved the getJobStatus method by adding a "GetJobStatus" check to the CloudComputeService. This check is used in the situation where we have no uploaded files to verify the "Pending" status of the job. In this scenario we go to the cloud and ask us for more information about the machine status.

