### PR TITLE
Correct placeholders in DB endpoint for aws deployment.

### DIFF
--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -56,7 +56,7 @@ GIS-DEV-OR.proms.report.url=http://ec2-54-213-205-234.us-west-2.compute.amazonaw
 
 # Default for AWS deployment
 DEFAULT.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og
-DEFAULT.jdbc.url=jdbc:mysql://DBENDPOINT/anvgl
+DEFAULT.jdbc.url=jdbc:mysql://DBHOST:DBPORT/DBNAME
 DEFAULT.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 DEFAULT.smtp.server=smtp-relay.csiro.au
 DEFAULT.localStageInDir=/local/stageIn/

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -61,4 +61,4 @@ DEFAULT.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 DEFAULT.smtp.server=smtp-relay.csiro.au
 DEFAULT.localStageInDir=/local/stageIn/
 DEFAULT.solutions.url=http://ec2-54-206-9-187.ap-southeast-2.compute.amazonaws.com/scm
-DEFAULT.proms.report.url=http://ec2-54-213-205-234.us-west-2.compute.amazonaws.com/id/report/
+DEFAULT.proms.report.url=http://proms-dev.geoanalytics.csiro.au/id/report/


### PR DESCRIPTION
A simple fix to use placeholders for DB{HOST,PORT,NAME} in the properties for the default deployment that is used by the AWS cloud formation script.