### PR TITLE
Anvgl 108

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/JobDownloadController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobDownloadController.java
@@ -341,7 +341,7 @@ public class JobDownloadController extends BasePortalController {
         		"&south=" + bbox.getSouthBoundLatitude() +
         		"&west=" + bbox.getWestBoundLongitude() +
         		"&east="+ bbox.getEastBoundLongitude();
-        String otherParams = "&temporal=all&time_start=&time_end=&horizStride=";
+        String otherParams = "";//"&temporal=all&time_start=&time_end=&horizStride=";
 
         String url = serviceUrl + "?var=" + description + netcdfsubsetserviceDimensions + otherParams;
 

--- a/src/main/java/org/auscope/portal/server/web/service/ANVGLProvenanceService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ANVGLProvenanceService.java
@@ -1,8 +1,19 @@
 package org.auscope.portal.server.web.service;
 
-import au.csiro.promsclient.*;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.logging.Log;
@@ -18,10 +29,15 @@ import org.auscope.portal.server.web.service.scm.Solution;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.*;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+
+import au.csiro.promsclient.Activity;
+import au.csiro.promsclient.Entity;
+import au.csiro.promsclient.ExternalReport;
+import au.csiro.promsclient.ProvenanceReporter;
+import au.csiro.promsclient.Report;
+import au.csiro.promsclient.ServiceEntity;
 
 /**
  * Created by Catherine Wise (wis056) on 3/10/2014. Modified by Stuart Woodman
@@ -228,7 +244,7 @@ public class ANVGLProvenanceService {
 
             for (CloudFileInformation information : fileInformationSet) {
                 URI inputURI = new URI(outputURL(job, information, serverURL()));
-                LOGGER.debug("New Input: " + inputURI.toString());
+                LOGGER.trace("New Input: " + inputURI.toString());
                 inputs.add(new Entity().setDataUri(inputURI).setWasAttributedTo(new URI(user.getId())));
             }
         } catch (PortalServiceException e) {
@@ -323,7 +339,7 @@ public class ANVGLProvenanceService {
             for (Entity potentialOutput : potentialOutputs) {
                 if (activity.usedEntities != null && !activity.usedEntities.contains(potentialOutput)) {
                     outputs.add(potentialOutput);
-                    LOGGER.debug("Added input from potentials list: " + potentialOutput);
+                    LOGGER.trace("Added input from potentials list: " + potentialOutput);
                 }
             }
             activity.setGeneratedEntities(outputs);

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -34,7 +34,7 @@ MORPH-BT.erddapservice.url=http://siss2.anu.edu.au/erddap/griddap/
 MORPH-BT.smtp.server=smtp-relay.csiro.au
 MORPH-BT.localStageInDir=C:\\temp\\anvgl\\
 MORPH-BT.solutions.url=http://ec2-54-206-9-187.ap-southeast-2.compute.amazonaws.com/scm
-MORPH-BT.proms.report.url=http://ec2-54-213-205-234.us-west-2.compute.amazonaws.com/id/report/
+MORPH-BT.proms.report.url=http://proms-dev.geoanalytics.csiro.au/id/report/
 
 # Geoff's laptop
 triplewood-bm.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og


### PR DESCRIPTION
Seems the NCI server does not like present, but unspecified parameters like "&temporal=all&time_start=&time_end=&horizStride=";
Looking back in history there does not seem to be a specific reason why they are there in the first place. 
Data download form NCI server works fine if empty parameters removed.
