### PR TITLE
Clone puppet modules into /root (ANVGL-109)

### DIFF
--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
@@ -12,7 +12,7 @@
 # /////////////////////////////
 
 # baseUrl -- git repository url
-baseUrl="https://github.com/AuScope/AVNGL-Portal.git"
+baseUrl="https://github.com/AuScope/ANVGL-Portal.git"
 
 # branch -- branch in the git repo
 branch="master"
@@ -83,7 +83,7 @@ if [ ! -d "$moduleDir/vl_common" ]; then
     fi
 
     # Assumes our temp dir does not already have content!
-    tmpModulesDir="/opt/anvgl"
+    tmpModulesDir="/opt/anvgl/modules"
     if [ "$1" !=  "" ]
     then
         baseUrl="$1"

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
@@ -83,7 +83,7 @@ if [ ! -d "$moduleDir/vl_common" ]; then
     fi
 
     # Assumes our temp dir does not already have content!
-    tmpModulesDir="/opt/anvgl/modules/"
+    tmpModulesDir="/opt/anvgl"
     if [ "$1" !=  "" ]
     then
         baseUrl="$1"

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
@@ -85,7 +85,7 @@ if [ ! -d "$moduleDir/vl_common" ]; then
     else
         sudo yum install -y wget git
     fi
-    tmpModulesDir="/tmp/modules/"
+    tmpModulesDir="/root/anvglmodules/"
     rm -rf "$tmpModulesDir"
     if [ "$1" !=  "" ]
     then

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
@@ -81,8 +81,9 @@ if [ ! -d "$moduleDir/vl_common" ]; then
     else
         sudo yum install -y wget git
     fi
-    tmpModulesDir="/root/anvglmodules/"
-    rm -rf "$tmpModulesDir"
+
+    # Assumes our temp dir does not already have content!
+    tmpModulesDir="/opt/anvgl/modules/"
     if [ "$1" !=  "" ]
     then
         baseUrl="$1"
@@ -113,8 +114,9 @@ if [ ! -d "$moduleDir/vl_common" ]; then
         exit 2
     fi
 
-    #Tidy up
-    rm -rf "$tmpModulesDir"
+    # Don't tidy up until we're sure this approach works with cloud-init
+    # # Tidy up
+    # rm -rf "$tmpModulesDir"
 else
     echo "Common vl modules found in $moduleDir/vl_common"
 fi

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-provisioning.sh
@@ -11,15 +11,11 @@
 #
 # /////////////////////////////
 
-# Use a local repo/branch until pulled into master
-baseUrl="https://github.com/squireg/ANVGL-Portal.git"
-branch="feature/sssc"
+# baseUrl -- git repository url
+baseUrl="https://github.com/AuScope/AVNGL-Portal.git"
 
-# # baseUrl -- git repository url
-# baseUrl="https://github.com/AuScope/AVNGL-Portal.git"
-
-# # branch -- branch in the git repo
-# branch="master"
+# branch -- branch in the git repo
+branch="master"
 
 # pathSuffix -- path to puppet modules in the repo
 pathSuffix="/vm/puppet/modules/"


### PR DESCRIPTION
Updated the vl-provisioning script to use /root/anvglmodules instead of /tmp/modules for the puppet modules when provisioning a job VM. Should avoid the /tmp shenanigans on bootstrap.