### PR TITLE
ANVGL-102: Return storage and compute ARNs from CF template

### DIFF
--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-cloudformation.json.tpl
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-cloudformation.json.tpl
@@ -300,5 +300,33 @@
         }
       }
     }
+  },
+  "Outputs": {
+    "ComputeARN": {
+      "Description": "ARN for the STS role used to run jobs in the client account.",
+      "Value": { "Fn::Join": [
+                   "",
+                   [
+                     "arn:aws:iam::",
+                     { "Ref": "AWS::AccountId" },
+                     ":role/",
+                     { "Ref": "AnvglStsRole" }
+                   ]
+                 ]
+               }
+    },
+    "StorageARN": {
+      "Description": "ARN for the role used to access S3 storage in the client account.",
+      "Value": { "Fn::Join": [
+                   "",
+                   [
+                     "arn:aws:iam::",
+                     { "Ref": "AWS::AccountId" },
+                     ":instance-profile/",
+                     { "Ref": "AnvglS3InstanceProfile" }
+                   ]
+                 ]
+               }
+    }
   }
 }


### PR DESCRIPTION
Added output descriptions to the cloudformation template, so that the STS role and the S3 instance profile ARNs are returned. The values can be retrieved from the Outputs tab in the CF console, or returned when using the command line tools.