### PR TITLE
ANVGL-130 Intermediate log/output file previews

### DIFF
--- a/src/main/java/org/auscope/portal/server/vegl/VGLJobStatusAndLogReader.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VGLJobStatusAndLogReader.java
@@ -40,7 +40,7 @@ public class VGLJobStatusAndLogReader extends BaseCloudController implements Job
      * @return
      */
     public ModelMap getSectionedLogs(VEGLJob job) throws PortalServiceException {
-        return getSectionedLogs(job, JobListController.VGL_LOG_FILE);
+        return getSectionedLogs(job, JobListController.VL_LOG_FILE);
     }
 
     /**
@@ -182,7 +182,7 @@ public class VGLJobStatusAndLogReader extends BaseCloudController implements Job
         }
 
         boolean jobStarted = containsFile(results, "workflow-version.txt");
-        boolean jobFinished = containsFile(results, JobListController.VGL_LOG_FILE);
+        boolean jobFinished = containsFile(results, JobListController.VL_TERMINATION_FILE);
 
         String expectedStatus = JobBuilderController.STATUS_PENDING;
         if (jobFinished) {

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
@@ -67,7 +67,10 @@ import org.springframework.web.servlet.ModelAndView;
 public class JobListController extends BaseCloudController  {
 
     /** The name of the log file that the job will use*/
-    public static final String VGL_LOG_FILE = "vl.sh.log";
+    public static final String VL_LOG_FILE = "vl.sh.log";
+
+    /** The name of the termination file that the job will use*/
+    public static final String VL_TERMINATION_FILE = "vl.end";
 
     /** Logger for this class */
     private final Log logger = LogFactory.getLog(getClass());
@@ -1071,7 +1074,7 @@ public class JobListController extends BaseCloudController  {
 
         ModelMap namedSections = null;
         try {
-            namedSections = (ModelMap)jobStatusLogReader.getSectionedLogs(job, file == null ? VGL_LOG_FILE : file);
+            namedSections = (ModelMap)jobStatusLogReader.getSectionedLogs(job, file == null ? VL_LOG_FILE : file);
         } catch (PortalServiceException ex) {
             return generateJSONResponseMAV(false, null, ex.getMessage());
         }

--- a/src/main/resources/org/auscope/portal/server/web/controllers/vl-bootstrap.sh
+++ b/src/main/resources/org/auscope/portal/server/web/controllers/vl-bootstrap.sh
@@ -20,6 +20,8 @@ export STORAGE_AUTH_VERSION="{7}"
 export OS_REGION_NAME="{8}"
 export VL_LOG_FILE_NAME="vl.sh.log"
 export VL_LOG_FILE="$WORKING_DIR/$VL_LOG_FILE_NAME"
+export VL_TERMINATION_FILE_NAME="vl.end"
+export VL_TERMINATION_FILE="$WORKING_DIR/$VL_TERMINATION_FILE_NAME"
 
 # Load our profile so this run is the same as a regular user login (to make debugging easier)
 source /etc/profile
@@ -40,6 +42,7 @@ echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
 echo "STORAGE_ENDPOINT = $STORAGE_ENDPOINT"
 echo "STORAGE_TYPE = $STORAGE_TYPE"
 echo "VL_LOG_FILE = $VL_LOG_FILE"
+echo "VL_TERMINATION_FILE = $VL_TERMINATION_FILE"
 echo "--------------------------------------"
 
 

--- a/src/main/webapp/js/vegl/jobwizard/forms/DuplicateJobForm.js
+++ b/src/main/webapp/js/vegl/jobwizard/forms/DuplicateJobForm.js
@@ -28,8 +28,10 @@ Ext.define('vegl.jobwizard.forms.DuplicateJobForm', {
             autoLoad : true,
             filters : [
                 function(item) {
-                    //These two files should not be copyable
-                    return item.get('name') !== 'vl.sh.log' && item.get('name') !== 'workflow-version.txt';
+                    //These three files should not be copyable
+                    return item.get('name') !== 'vl.sh.log' &&
+                           item.get('name') !== 'workflow-version.txt' &&
+                           item.get('name') !== 'vl.end';
                 }
             ],
             proxy : {

--- a/src/main/webapp/js/vegl/models/FileRecord.js
+++ b/src/main/webapp/js/vegl/models/FileRecord.js
@@ -10,5 +10,20 @@ Ext.define('vegl.models.FileRecord', {
         { name: 'parentPath', type: 'string' } //Parent path for where the input file is located
     ],
 
-    idProperty: 'name'
+    idProperty: 'name',
+
+    /**
+     * Returns true if this file matches a known pattern for a "utility" file that the end user
+     * will not find of any use
+     */
+    isVlUtilityFile: function() {
+        switch(this.get('name')) {
+        case 'activity.ttl':
+        case 'vl.end':
+        case 'workflow-version.txt':
+            return true;
+        default:
+            return false;
+        }
+    }
 });

--- a/src/main/webapp/js/vegl/preview/FilePreviewMixin.js
+++ b/src/main/webapp/js/vegl/preview/FilePreviewMixin.js
@@ -14,5 +14,14 @@ Ext.define('vegl.preview.FilePreviewMixin', {
      *
      * returns nothing
      */
-    preview : portal.util.UnimplementedFunction
+    preview : portal.util.UnimplementedFunction,
+
+    /**
+     * Can be overridden
+     *
+     * Forces a complete refresh of the current preview.
+     */
+    handleRefresh : function() {
+        this.preview(this.job, this.fileName, this.size);
+    }
 });

--- a/src/main/webapp/js/vegl/preview/FilePreviewPanel.js
+++ b/src/main/webapp/js/vegl/preview/FilePreviewPanel.js
@@ -33,8 +33,25 @@ Ext.define('vegl.preview.FilePreviewPanel', {
 
         Ext.apply(config, {
             layout: 'card',
-            items: previewers
-
+            items: previewers,
+            dockedItems: [{
+                xtype: 'toolbar',
+                dock: 'bottom',
+                items: [{
+                    xtype: 'tbfill'
+                },{
+                    xtype: 'button',
+                    text: 'Refresh',
+                    iconCls: 'refresh-icon',
+                    scope: this,
+                    handler: function() {
+                        var preview = this.getLayout().getActiveItem();
+                        if (preview.handleRefresh) {
+                            preview.handleRefresh();
+                        }
+                    }
+                }]
+            }]
         });
 
         this.callParent(arguments);

--- a/src/main/webapp/js/vegl/preview/ImagePreview.js
+++ b/src/main/webapp/js/vegl/preview/ImagePreview.js
@@ -24,7 +24,25 @@ Ext.define('vegl.preview.ImagePreview', {
      */
     preview : function(job, fileName, size) {
         var img = this.getEl().down('img');
-        img.dom.setAttribute('src', 'secure/getImagePreview.do?jobId=' + job.get('id') + '&file=' + fileName);
+        var mask = new Ext.LoadMask({
+            msg: 'Loading Image...',
+            target: this.ownerCt
+        });
+        mask.show();
+
+        var hideMask = function() {
+            mask.hide();
+            img.un('load', hideMask);
+            img.un('error', hideMask);
+        };
+        img.on('load', hideMask);
+        img.on('error', hideMask);
+
+        img.dom.setAttribute('src', 'secure/getImagePreview.do?jobId=' + job.get('id') + '&file=' + fileName + '&_dc=' + Math.random());
+
+        this.job = job;
+        this.fileName = fileName;
+        this.size = size;
     },
 
     /**

--- a/src/main/webapp/js/vegl/preview/LogPreview.js
+++ b/src/main/webapp/js/vegl/preview/LogPreview.js
@@ -11,32 +11,15 @@ Ext.define('vegl.preview.LogPreview', {
         preview: 'vegl.preview.FilePreviewMixin'
     },
 
-    currentJob : null,
-    currentFile : null,
+    job : null,
+    fileName : null,
     currentRequest : null,
 
     constructor : function(config) {
 
         Ext.apply(config, {
             autoScroll : true,
-            items : [],
-            dockedItems: [{
-                xtype: 'toolbar',
-                dock: 'bottom',
-                items: [{
-                    xtype: 'tbfill'
-                },{
-                    xtype: 'button',
-                    text: 'Refresh',
-                    iconCls: 'refresh-icon',
-                    scope: this,
-                    handler: function() {
-                        if (this.currentJob) {
-                            this.preview(this.currentJob, this.currentFile);
-                        }
-                    }
-                }]
-            }]
+            items : []
         });
 
         this.callParent(arguments);
@@ -55,8 +38,9 @@ Ext.define('vegl.preview.LogPreview', {
 
         if (job.get('status') === vegl.models.Job.STATUS_UNSUBMITTED) {
             this.clearLogs(true, 'This job hasn\'t been submitted yet.');
-            this.currentJob = job;
-            this.currentFile = fileName;
+            this.job = job;
+            this.fileName = fileName;
+            this.size = size;
             return;
         }
 
@@ -67,14 +51,15 @@ Ext.define('vegl.preview.LogPreview', {
         }
 
         this.clearLogs();
-        this.currentJob = job;
-        this.currentFile = fileName;
+        this.job = job;
+        this.fileName = fileName;
+        this.size = size;
 
         this.currentRequest = Ext.Ajax.request({
             url : 'secure/getSectionedLogs.do',
             params : {
                 jobId : job.get('id'),
-                file: this.currentFile
+                file: this.fileName
             },
             scope : this,
             callback : function(options, success, response) {
@@ -120,6 +105,8 @@ Ext.define('vegl.preview.LogPreview', {
                                     doc.write(sections[iframe.getAttribute('sectionName')]);
                                     doc.close();
                                     doc.body.setAttribute('style', 'white-space:pre;font-family:monospace;');
+
+                                    doc.body.scrollTo(0, 999999);
                                 }
                             }
                         }]
@@ -144,8 +131,10 @@ Ext.define('vegl.preview.LogPreview', {
      * Removes logs from this panel. Optionally adds a replacement tab indicating this panel is empty
      */
     clearLogs : function(addEmptyTab, emptyTabMsg) {
-        this.currentJob = null;
-        this.currentFile = null;
+        this.job = null;
+        this.fileName = null;
+        this.size = null;
+
         this.removeAll(true);
         if (addEmptyTab) {
             this.addEmptyTab(emptyTabMsg ? emptyTabMsg : 'No job selected.');

--- a/src/main/webapp/js/vegl/preview/PlainTextPreview.js
+++ b/src/main/webapp/js/vegl/preview/PlainTextPreview.js
@@ -34,14 +34,15 @@ Ext.define('vegl.preview.PlainTextPreview', {
         }
 
         this.clearPreview();
-        this.currentJob = job;
-        this.currentFile = fileName;
+        this.job = job;
+        this.fileName = fileName;
+        this.size = size;
 
         this.currentRequest = Ext.Ajax.request({
             url : 'secure/getPlaintextPreview.do',
             params : {
                 jobId : job.get('id'),
-                file: this.currentFile,
+                file: this.fileName,
                 maxSize: 20 * 1024 //20 KB
             },
             scope : this,
@@ -80,8 +81,9 @@ Ext.define('vegl.preview.PlainTextPreview', {
      * Removes logs from this panel. Optionally adds a replacement tab indicating this panel is empty
      */
     clearPreview : function(addEmptyTab, emptyTabMsg) {
-        this.currentJob = null;
-        this.currentFile = null;
+        this.job = null;
+        this.fileName = null;
+        this.size = null;
         this.writeText('');
     }
 });

--- a/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
@@ -90,7 +90,10 @@ Ext.define('vegl.widgets.JobFilesPanel', {
                             }
                         }
                     }
-                }
+                },
+                filters: [function(item) {
+                    return !item.isVlUtilityFile(); //Don't display the utility files
+                }]
             }),
             columns: [{ header: 'Filename', width: 200, sortable: true, dataIndex: 'name'},
                       { header: 'Size', width: 100, sortable: true, dataIndex: 'size', renderer: Ext.util.Format.fileSize, align: 'right'}],

--- a/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
@@ -125,7 +125,6 @@ Ext.define('vegl.widgets.JobFilesPanel', {
         ajaxProxy.extraParams.jobId = job.get('id');
         ajaxProxy.abort(); //Stop loading any previous job files
         this.currentJob = job;
-        store.removeAll(false);
         store.load();
     },
 

--- a/src/test/java/org/auscope/portal/server/vegl/TestVGLJobStatusAndLogReader.java
+++ b/src/test/java/org/auscope/portal/server/vegl/TestVGLJobStatusAndLogReader.java
@@ -202,7 +202,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
         final CloudFileInformation[] jobDoneFiles = new CloudFileInformation[] {
                 new CloudFileInformation("key3/workflow-version.txt", 100L, "http://public.url3/filename"),
                 new CloudFileInformation("key3/filename2", 101L, "http://public.url3/filename2"),
-                new CloudFileInformation("key3/vl.sh.log", 102L, "http://public.url3/filename3"),
+                new CloudFileInformation("key3/vl.end", 102L, "http://public.url3/filename3"),
         };
 
         final List<VglDownload> downloads = new ArrayList<>();
@@ -338,7 +338,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
         context.checking(new Expectations() {{
             allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
-            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(returnValue(logContents));
+            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(returnValue(logContents));
         }});
 
         ModelMap map = jobStatLogReader.getSectionedLogs(mockJob);
@@ -386,7 +386,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
             allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeServiceId));
-            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(throwException(new PortalServiceException("error")));
+            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(throwException(new PortalServiceException("error")));
             oneOf(mockCloudComputeServices[0]).getConsoleLog(mockJob);will(returnValue(null));
         }});
 
@@ -408,7 +408,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
             allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeServiceId));
-            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(throwException(new PortalServiceException("error")));
+            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(throwException(new PortalServiceException("error")));
             oneOf(mockCloudComputeServices[0]).getConsoleLog(mockJob);will(throwException(new PortalServiceException("error")));
         }});
 
@@ -431,7 +431,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
             allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeServiceId));
-            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(throwException(new PortalServiceException("error")));
+            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(throwException(new PortalServiceException("error")));
             oneOf(mockCloudComputeServices[0]).getConsoleLog(mockJob);will(returnValue(logContents));
         }});
 
@@ -451,7 +451,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
         context.checking(new Expectations() {{
             allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
-            allowing(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(returnValue(logContents));
+            allowing(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(returnValue(logContents));
         }});
 
         String result = jobStatLogReader.getSectionedLog(mockJob, "environment");
@@ -473,7 +473,7 @@ public class TestVGLJobStatusAndLogReader extends PortalTestClass {
             allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
             allowing(mockCloudStorageServices[0]).getId();will(returnValue(storageServiceId));
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeServiceId));
-            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VGL_LOG_FILE);will(throwException(new PortalServiceException("error")));
+            oneOf(mockCloudStorageServices[0]).getJobFile(mockJob, JobListController.VL_LOG_FILE);will(throwException(new PortalServiceException("error")));
             oneOf(mockCloudComputeServices[0]).getConsoleLog(mockJob);will(returnValue(null));
         }});
 


### PR DESCRIPTION
The end user wishes to read logs as they are written (or at a regular interval), likewise some output files can be expected to be appended to/rewritten.

1) Make the intermediate logs visible (need work on backend/bootstrap scripts)
2) Make the file browser not completely clear on refresh
3) Add a refresh button to the preview for images

Also added:

* Logs now scroll to bottom by default
* "Internal files" are now hidden

If you want to test this before pulling, you will need to update config.properties vm.sh to point to this branch's version of vl.sh
