### PR TITLE
Anvgl 113 - handle "no" answer to continuing with no data

### DIFF
--- a/src/main/webapp/js/vegl/jobwizard/forms/JobObjectForm.js
+++ b/src/main/webapp/js/vegl/jobwizard/forms/JobObjectForm.js
@@ -420,28 +420,10 @@ Ext.define('vegl.jobwizard.forms.JobObjectForm', {
                 wizardState.ncpus = computeType.get('vcpus');
                 wizardState.nrammb = computeType.get('ramMB');
 
-                // Check with the user if no data set has been captured.
-                var numDownloadReqs = 0;
-                if (updatedJob.jobDownloads !== null) {
-                    numDownloadReqs = updatedJob.jobDownloads.length;
-                }
-                if (!wizardState.skipConfirmPopup && numDownloadReqs === 0) {
-                    Ext.Msg.confirm('Confirm',
-                            'No data set has been captured. Do you want to continue?',
-                            function(button) {
-                                if (button === 'yes') {
-                                    wizardState.skipConfirmPopup = true;
-                                    callback(true);
-                                    return;
-                                } else {
-                                    callback(false);
-                                    return;
-                                }
-                        });
-                } else {
-                    callback(true);
-                    return;
-                }
+                // Don't need to check for data sets at this point since that
+                // was done at the start. Continue with the wizard.
+                callback(true);
+                return;
             }
         });
     },

--- a/src/main/webapp/js/vegl/jobwizard/forms/JobUploadForm.js
+++ b/src/main/webapp/js/vegl/jobwizard/forms/JobUploadForm.js
@@ -43,18 +43,27 @@ Ext.define('vegl.jobwizard.forms.JobUploadForm', {
 
                                     if (responseObj.success) {
                                         jobUploadFrm.wizardState.jobId = responseObj.data[0].id;
+                                        jobUploadFrm.updateFileList();
                                     }
                                 }
                             });
-                            jobUploadFrm.updateFileList();
                         }
                         else {
-                            // Ext.bind(jobUploadFrm.updateFileList, jobUploadFrm);
-                        	 if (jobUploadFrm.wizardState.jobId === undefined) {
-                                 jobUploadFrm.createJob(function() { jobUploadFrm.updateFileList(); });
-                             } else {
-                                 jobUploadFrm.updateFileList();                            	 
-                             }
+                        	  if (jobUploadFrm.wizardState.jobId === undefined) {
+                                jobUploadFrm.confirmContinue(function(cont) {
+                                    if (cont) {
+                                        jobUploadFrm.createJob(function() {
+                                            jobUploadFrm.updateFileList();
+                                        });
+                                    }
+                                    else {
+                                        Ext.util.History.back();
+                                    }
+                                });
+                            }
+                            else {
+                                jobUploadFrm.updateFileList();
+                            }
                         }
                     }
             },
@@ -198,12 +207,49 @@ Ext.define('vegl.jobwizard.forms.JobUploadForm', {
     },
 
     /**
+     * Confirm with the user whether to continue if no dataset has been captured.
+     *
+     * Calls callback passing true/false to indicate whether to continue.
+     *
+     * @function
+     * @param {function} callback
+     */
+    confirmContinue: function(callback) {
+        // Did the user already confirm to continue earlier?
+        if (this.wizardState.skipConfirmPopup) {
+            callback(true);
+            return;
+        }
+
+        // If no data set has been captured in the session and we have no job
+        // then check with the user whether or not to continue.
+        if (this.wizardState.jobId === undefined && this.getNumDownloadRequests() === 0) {
+            Ext.Msg.confirm('Confirm',
+                            'No data set has been captured. Do you want to continue?',
+                            function(button) {
+                                if (button === 'yes') {
+                                    this.wizardState.skipConfirmPopup = true;
+                                    callback(true);
+                                    return;
+                                } else {
+                                    callback(false);
+                                    return;
+                                }
+                            });
+        }
+
+        // Continue by default
+        callback(true);
+    },
+
+    /**
      * Creates a new job and hooks the generated JobId to the work-flow
      * @function
      * @param {function} callback
      */
     createJob : function(callback) {
         var wizardState = this.wizardState;
+        var self = this;
 
         this.createSeries(wizardState, function() {
             var params = {};
@@ -248,31 +294,8 @@ Ext.define('vegl.jobwizard.forms.JobUploadForm', {
                     var updatedJob = responseObj.data[0];
                     wizardState.jobId = updatedJob.id;
 
-                    // Check with the user if no data set has been captured.
-                    var numDownloadReqs = 0;
-                    if (updatedJob.jobDownloads !== null) {
-                        numDownloadReqs = updatedJob.jobDownloads.length;
-                    }
-                    if (!wizardState.skipConfirmPopup && numDownloadReqs === 0) {
-                        Ext.Msg.confirm('Confirm',
-                                        'No data set has been captured. Do you want to continue?',
-                                        function(button) {
-                                            if (button === 'yes') {
-                                                wizardState.skipConfirmPopup = true;
-                                                callback(true);
-                                                return;
-                                            } else {
-                                                callback(false);
-                                                return;
-                                            }
-                                        });
-                    } else {
-                        callback(true);
-                        return;
-                    }
-
+                    // continue with the wizard
                     callback(true);
-                    return;
                 }
             });
         });


### PR DESCRIPTION
Ask the user once whether to continue if no data is selected during job submission, and honour a "no" answer by going back in the browser history and not creating a job object in the database.