### PR TITLE
Added gitattributes to force LF settings

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/MenuController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/MenuController.java
@@ -44,7 +44,7 @@ public class MenuController {
    private String googleAnalyticsKey;
 
    @Autowired
-   public MenuController(@Value("${HOST.googlemap.key}") String googleMapKey, @Value("${HOST.google.analytics.key:''}") String googleAnalyticsKey) {
+   public MenuController(@Value("${HOST.googlemap.key}") String googleMapKey, @Value("${HOST.google.analytics.key:}") String googleAnalyticsKey) {
        this.buildStamp = null;
        this.googleMapKey = googleMapKey;
        this.googleAnalyticsKey = googleAnalyticsKey;


### PR DESCRIPTION
Some unit tests under check for unix style line endings in some of the script files. These can fail under Windows if you have autocrlf setup. This file will force these "sensitive" files into Unix style