### PR TITLE
Anvgl 168   change job selection

### DIFF
--- a/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
@@ -319,6 +319,7 @@ Ext.define('vegl.widgets.JobFilesPanel', {
     listFilesForJob : function(job) {
         this.currentJobId = job.get('id');
         this.updateFileStore();
+        this.getSelectionModel().clearSelections();
     }
 });
 


### PR DESCRIPTION
Originally, changing job selection would clear the preview panel but it wouldn't clear the job selection.