### PR TITLE
VGL-183 Added a detailed Status Log viewer to jobs

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/BaseModelController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/BaseModelController.java
@@ -30,8 +30,6 @@ public class BaseModelController extends BasePortalController {
      * @return The VEGLJob object on success or null otherwise.
      */
     protected VEGLJob attemptGetJob(Integer jobId, ANVGLUser user) {
-        log.info("Getting job with ID " + jobId);
-
         VEGLJob job = null;
 
         //Check we have a user email

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
@@ -1101,7 +1101,7 @@ public class JobListController extends BaseCloudController  {
      * @return
      */
     @RequestMapping("/secure/getRawInstanceLogs.do")
-    public ModelAndView getSectionedLogs(HttpServletRequest request,
+    public ModelAndView getRawInstanceLogs(HttpServletRequest request,
             @RequestParam("jobId") Integer jobId,
             @AuthenticationPrincipal ANVGLUser user) {
         //Lookup the job whose logs we are accessing

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
@@ -1116,6 +1116,9 @@ public class JobListController extends BaseCloudController  {
                 return generateJSONResponseMAV(false, null, "The compute service exists for this job no longer exists.");
             }
             String rawLog = service.getConsoleLog(job, 5000);
+            if (StringUtils.isEmpty(rawLog)) {
+                return generateJSONResponseMAV(false, null, "No compute logs were accessible for this job.");
+            }
             return generateJSONResponseMAV(true, rawLog, "");
         } catch (PortalServiceException ex) {
             return generateJSONResponseMAV(false, null, ex.getMessage());

--- a/src/main/webapp/WEB-INF/jsp/joblist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/joblist.jsp
@@ -64,6 +64,7 @@
 
     <script type="text/javascript" src="js/vegl/widgets/CodeEditorField.js"></script>
     <script type="text/javascript" src="js/vegl/models/FileRecord.js"></script>
+    <script type="text/javascript" src="js/vegl/models/AuditLog.js"></script>
     <script type="text/javascript" src="js/vegl/models/Job.js"></script>
     <script type="text/javascript" src="js/vegl/models/Series.js"></script>
     <script type="text/javascript" src="js/vegl/models/MachineImage.js"></script>
@@ -88,6 +89,7 @@
     <script type="text/javascript" src="js/vegl/widgets/MachineImageCombo.js"></script>
     <script type="text/javascript" src="js/vegl/widgets/JobsTree.js"></script>
     <script type="text/javascript" src="js/vegl/widgets/JobsPanel.js"></script>
+    <script type="text/javascript" src="js/vegl/widgets/JobStatusWindow.js"></script>
     <script type="text/javascript" src="js/vegl/widgets/SeriesPanel.js"></script>
     <script type="text/javascript" src="js/vegl/widgets/FolderPanel.js"></script>
     <script type="text/javascript" src="js/vegl/widgets/JobRegisterPanel.js"></script>

--- a/src/main/webapp/css/vl-styles.css
+++ b/src/main/webapp/css/vl-styles.css
@@ -65,6 +65,10 @@ body.ext-chrome table.x-btn .x-btn-small td.x-btn-mc em a {
     background-image: url("../portal-core/img/grid.png") !important
 }
 
+.status-icon {
+    background-image: url("../portal-core/img/information.png") !important
+}
+
 .refresh-icon {
     background-image: url("../portal-core/img/refresh.png") !important
 }

--- a/src/main/webapp/js/vegl/models/AuditLog.js
+++ b/src/main/webapp/js/vegl/models/AuditLog.js
@@ -1,0 +1,22 @@
+/**
+ * A FileRecord represents a single input/output file being used by the VL workflow
+ */
+Ext.define('vegl.models.AuditLog', {
+    extend: 'Ext.data.Model',
+
+    fields: [
+        { name: 'id', type: 'int' },
+        { name: 'jobId', type: 'int' },
+        { name: 'jobId', type: 'int' },
+        { name: 'fromStatus', type: 'string' },
+        { name: 'toStatus', type: 'string' },
+        { name: 'message', type: 'string' },
+        { name: 'transitionDate', type: 'date', convert: function(value, record) {
+            if (!value) {
+                return null;
+            } else {
+                return new Date(value);
+            }
+        }}
+    ]
+});

--- a/src/main/webapp/js/vegl/models/Job.js
+++ b/src/main/webapp/js/vegl/models/Job.js
@@ -16,7 +16,22 @@ Ext.define('vegl.models.Job', {
         STATUS_ERROR : "ERROR",
         STATUS_DELETED : "DELETED",
         STATUS_PROVISIONING : "Provisioning",
-        STATUS_WALLTIME_EXCEEDED : "WALLTIME EXCEEDED"
+        STATUS_WALLTIME_EXCEEDED : "WALLTIME EXCEEDED",
+
+
+        STATUS_DESCRIPTIONS : {
+            "Failed" : "An unexpected error has occurred. Please check the audit log for more information.",
+            "Active" : "The job has successfully allocated computing resources and has begun processing the job script.",
+            "Pending" : "The job has successfully allocated computing resources but is awaiting the start of the job script.",
+            "Done" : "The job has finished executing the job script.",
+            "Cancelled" : "The job execution has been cancelled by the user.",
+            "Saved" : "The job has not yet been submitted for processing.",
+            "In Queue" : "The job is in queue for submission to the cloud.",
+            "ERROR" : "An unexpected error has occurred. Please check the audit log for more information.",
+            "DELETED" : "The job has been deleted by the user.",
+            "Provisioning" : "The job is currently trying to allocate computing resources.",
+            "WALLTIME EXCEEDED" : "The job exceeded the walltime specified and has terminated."
+        }
     },
 
     fields: [

--- a/src/main/webapp/js/vegl/widgets/JobStatusWindow.js
+++ b/src/main/webapp/js/vegl/widgets/JobStatusWindow.js
@@ -1,0 +1,177 @@
+/**
+ * Ext.window.Window specialisation for rendering advanced information about a Jobs status
+ */
+Ext.define('vegl.widgets.JobStatusWindow', {
+    extend : 'Ext.window.Window',
+
+    /**
+     * Accepts the config for a Ext.grid.Panel along with the following additions:
+     *
+     * job : vegl.models.Job - Job object to view advanced job status information
+     */
+    constructor : function(config) {
+        var status = config.job.get('status');
+        var statusDescription = vegl.models.Job.STATUS_DESCRIPTIONS[status];
+        var statusStyle = vegl.widgets.JobsPanel.styleFromStatus(status);
+        var showInstanceLog;
+
+        var auditLogStore = Ext.create('Ext.data.Store', {
+            model : 'vegl.models.AuditLog',
+            proxy : {
+                type : 'ajax',
+                url : 'secure/getAuditLogsForJob.do',
+                extraParams : {jobId : config.job.get('id')},
+                reader : {
+                    type : 'json',
+                    rootProperty : 'data'
+                }
+            },
+            autoLoad: true,
+            sorters: [{
+                property: 'transitionDate',
+                direction: 'DESC'
+            }]
+        });
+
+        switch (status) {
+        case vegl.models.Job.STATUS_PENDING:
+        case vegl.models.Job.STATUS_PROVISIONING:
+        case vegl.models.Job.STATUS_ACTIVE:
+            showInstanceLog = true;
+            break;
+        default:
+            showInstanceLog = false;
+            break;
+        }
+
+        Ext.apply(config, {
+            title: 'Status information for ' + config.job.get('name'),
+            layout: {
+                type: 'vbox',
+                align: 'stretch',
+                pack: 'start'
+            },
+            items:[{
+                xtype: 'container',
+                height: 60,
+                layout: {
+                    type: 'hbox',
+                    align: 'stretch',
+                    pack: 'start'
+                },
+                items: [{
+                    xtype: 'datadisplayfield',
+                    itemId: 'status',
+                    cls: 'vl-job-details',
+                    fieldLabel: 'Status',
+                    value: Ext.util.Format.format('<span title="{0}" style="color:{1};">{2}</span>', statusStyle.tip, statusStyle.color, statusStyle.text)
+                },{
+                    xtype: 'displayfield',
+                    value: statusDescription,
+                    padding: '10 0 0 10',
+                    fieldStyle: 'font-style: italic; font-size:16px; color: #aaa;',
+                    flex: 1
+                }]
+            },{
+                xtype: 'tabpanel',
+                flex: 1,
+                plain: true,
+                items: [{
+                    title: 'Status Log',
+                    layout: 'fit',
+                    items: [{
+                        xtype: 'gridpanel',
+                        store: auditLogStore,
+                        viewConfig: {
+                          enableTextSelection: true
+                        },
+                        columns: [{
+                            text: 'Status',
+                            dataIndex: 'toStatus',
+                            renderer: function(value) {
+                                var style = vegl.widgets.JobsPanel.styleFromStatus(value);
+                                return Ext.util.Format.format('<span title="{0}" style="color:{1};">{2}</span>', style.tip, style.color, style.text);
+                            }
+                        },{
+                            text: 'Changed At',
+                            dataIndex: 'transitionDate',
+                            width: 160,
+                            sortable: true,
+                            renderer: Ext.util.Format.dateRenderer('d M Y, H:i:s')
+                        },{
+                            text: 'Message',
+                            dataIndex: 'message',
+                            flex: 1,
+                            renderer: function(value) {
+                                return Ext.util.Format.format('<span title="{0}">{0}</span>', value);
+                            }
+                        }]
+                    }]
+                },{
+                    title: 'Raw Compute Logs',
+                    hidden: !showInstanceLog,
+                    layout: 'fit',
+                    items: [{
+                        xtype: 'plaintextpreview',
+                        listeners: {
+                            scope: this,
+                            afterrender: function() {
+                                this.updateRawInstanceLog();
+                            }
+                        },
+                        dockedItems: [{
+                            xtype: 'toolbar',
+                            dock: 'bottom',
+                            items: [{
+                                xtype: 'tbfill'
+                            },{
+                                xtype: 'button',
+                                text: 'Refresh',
+                                iconCls: 'refresh-icon',
+                                scope: this,
+                                handler: function() {
+                                    this.updateRawInstanceLog();
+                                }
+                            }]
+                        }]
+                    }]
+                }]
+            }]
+        });
+
+        this.callParent(arguments);
+    },
+
+
+    updateRawInstanceLog: function() {
+        var preview = this.down('plaintextpreview');
+
+        if (preview._currentRequest) {
+            Ext.Ajax.abort(preview._currentRequest);
+            preview._currentRequest = null;
+        }
+
+        var mask = new Ext.LoadMask({
+            msg    : 'Accessing logs...',
+            target : preview
+        });
+        mask.show();
+        preview._currentRequest = portal.util.Ajax.request({
+            url: 'secure/getRawInstanceLogs.do',
+            params: {
+                jobId: this.job.get('id')
+            },
+            callback: function() {
+                mask.hide();
+                preview._currentRequest = null;
+            },
+            success: function(data) {
+                preview.writeText(data);
+            },
+            failure: function(message) {
+                preview.writeText('Unable to access the compute logs directly: ' + message);
+            }
+        });
+    }
+
+});

--- a/src/main/webapp/js/vegl/widgets/JobsTree.js
+++ b/src/main/webapp/js/vegl/widgets/JobsTree.js
@@ -133,6 +133,26 @@ Ext.define('vegl.widgets.JobsTree', {
             }
         });
 
+        this.statusJobAction = new Ext.Action({
+            text: 'Status',
+            iconCls: 'status-icon',
+            scope : this,
+            disabled : true,
+            handler: function() {
+                var selection = this.getSelectionModel().getSelection();
+                if (selection.length > 0) {
+                    var popup = Ext.create('vegl.widgets.JobStatusWindow', {
+                        job: selection[0],
+                        modal: true,
+                        width: 700,
+                        height: 400
+                    });
+
+                    popup.show();
+                }
+            }
+        });
+
         Ext.apply(config, {
             rootVisible: false,
             store : Ext.create('Ext.data.TreeStore', {
@@ -223,6 +243,10 @@ Ext.define('vegl.widgets.JobsTree', {
                             items.push(this.duplicateJobAction);
                         }
 
+                        if (!this.statusJobAction.isDisabled()) {
+                            items.push(this.statusJobAction);
+                        }
+
                         Ext.create('Ext.menu.Menu', {
                             width: 100,
                             items: items
@@ -256,6 +280,7 @@ Ext.define('vegl.widgets.JobsTree', {
             this.duplicateJobAction.setDisabled(true);
             this.submitJobAction.setDisabled(true);
             this.editJobAction.setDisabled(true);
+            this.statusJobAction.setDisabled(true);
         } else if(selections.length > 1) {
         	// Currently only allow deletion of multiple jobs if none are active
         	this.cancelJobAction.setDisabled(true);
@@ -263,12 +288,14 @@ Ext.define('vegl.widgets.JobsTree', {
             this.duplicateJobAction.setDisabled(true);
             this.submitJobAction.setDisabled(true);
             this.editJobAction.setDisabled(true);
+            this.statusJobAction.setDisabled(true);
         } else if (!Ext.isNumber(Number(selections[0].get('id')))) {
             this.cancelJobAction.setDisabled(true);
             this.deleteJobAction.setDisabled(false);
             this.duplicateJobAction.setDisabled(true);
             this.submitJobAction.setDisabled(true);
             this.editJobAction.setDisabled(true);
+            this.statusJobAction.setDisabled(true);
         } else {
             // Change the job available options based on its actual status
             switch(selections[0].get('status')) {
@@ -278,6 +305,7 @@ Ext.define('vegl.widgets.JobsTree', {
                     this.duplicateJobAction.setDisabled(false);
                     this.submitJobAction.setDisabled(true);
                     this.editJobAction.setDisabled(true);
+                    this.statusJobAction.setDisabled(false);
                     break;
                 case vegl.models.Job.STATUS_UNSUBMITTED:
                     this.cancelJobAction.setDisabled(true);
@@ -285,6 +313,7 @@ Ext.define('vegl.widgets.JobsTree', {
                     this.duplicateJobAction.setDisabled(true);
                     this.submitJobAction.setDisabled(false);
                     this.editJobAction.setDisabled(false);
+                    this.statusJobAction.setDisabled(true);
                     break;
                 case vegl.models.Job.STATUS_ERROR:
                 case vegl.models.Job.STATUS_WALLTIME_EXCEEDED:
@@ -294,6 +323,7 @@ Ext.define('vegl.widgets.JobsTree', {
                     this.duplicateJobAction.setDisabled(false);
                     this.submitJobAction.setDisabled(true);
                     this.editJobAction.setDisabled(true);
+                    this.statusJobAction.setDisabled(false);
                     break;
                 default:
                     // Job status is STATUS_PENDING
@@ -302,6 +332,7 @@ Ext.define('vegl.widgets.JobsTree', {
                     this.duplicateJobAction.setDisabled(false);
                     this.submitJobAction.setDisabled(true);
                     this.editJobAction.setDisabled(true);
+                    this.statusJobAction.setDisabled(false);
                     break;
             }
         }

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
@@ -29,6 +29,7 @@ import org.auscope.portal.jmock.VEGLSeriesMatcher;
 import org.auscope.portal.server.vegl.VEGLJob;
 import org.auscope.portal.server.vegl.VEGLJobManager;
 import org.auscope.portal.server.vegl.VEGLSeries;
+import org.auscope.portal.server.vegl.VGLJobAuditLogDao;
 import org.auscope.portal.server.vegl.VGLJobStatusAndLogReader;
 import org.auscope.portal.server.vegl.VGLPollingJobQueueManager;
 import org.auscope.portal.server.web.security.ANVGLUser;
@@ -53,6 +54,7 @@ public class TestJobListController extends PortalTestClass {
     private FileStagingService mockFileStagingService;
     private CloudComputeService[] mockCloudComputeServices;
     private VGLJobStatusAndLogReader mockVGLJobStatusAndLogReader;
+    private VGLJobAuditLogDao mockJobAuditLogDao;
     private ANVGLUser mockPortalUser;
     private JobStatusMonitor mockJobStatusMonitor;
     private HttpServletRequest mockRequest;
@@ -73,6 +75,7 @@ public class TestJobListController extends PortalTestClass {
         mockJobStatusMonitor = context.mock(JobStatusMonitor.class);
         mockResponse = context.mock(HttpServletResponse.class);
         mockRequest = context.mock(HttpServletRequest.class);
+        mockJobAuditLogDao = context.mock(VGLJobAuditLogDao.class);
         mockPortalUser = context.mock(ANVGLUser.class);
         final List<VEGLJob> mockJobs=new ArrayList<>();
         vglPollingJobQueueManager = new VGLPollingJobQueueManager();
@@ -85,7 +88,7 @@ public class TestJobListController extends PortalTestClass {
 
         controller = new JobListController(mockJobManager,
                 mockCloudStorageServices, mockFileStagingService,
-                mockCloudComputeServices, mockVGLJobStatusAndLogReader, mockJobStatusMonitor,null,null,null,vglPollingJobQueueManager, "dummy@dummy.com");
+                mockCloudComputeServices, mockVGLJobStatusAndLogReader, mockJobStatusMonitor,null,null,null,vglPollingJobQueueManager, "dummy@dummy.com", mockJobAuditLogDao);
     }
 
     @After
@@ -183,7 +186,7 @@ public class TestJobListController extends PortalTestClass {
 
         JobListController myController = new JobListController(queueMockJobManager,
                 mockCloudStorageServices, mockFileStagingService,
-                mockCloudComputeServices, mockVGLJobStatusAndLogReader, mockJobStatusMonitor,null,null,null,vglPollingJobQueueManager, "dummy@dummy.com");
+                mockCloudComputeServices, mockVGLJobStatusAndLogReader, mockJobStatusMonitor,null,null,null,vglPollingJobQueueManager, "dummy@dummy.com", mockJobAuditLogDao);
 
         Assert.assertEquals(2, vglPollingJobQueueManager.getQueue().size());
 
@@ -1232,5 +1235,83 @@ public class TestJobListController extends PortalTestClass {
             Assert.assertArrayEquals(data1, fis1Data);
             Assert.assertArrayEquals(data2, fis2Data);
         }
+    }
+
+    /**
+     * Tests requesting instance logs in the best case scenario
+     */
+    @Test
+    public void testGetRawInstanceLogs() throws Exception {
+        final String userEmail = "exampleuser@email.com";
+        final int jobId = 1234;
+        final VEGLJob mockJob = context.mock(VEGLJob.class);
+        final String consoleData = "console\ndata\n";
+
+        context.checking(new Expectations() {{
+            allowing(mockPortalUser).getEmail();will(returnValue(userEmail));
+
+            oneOf(mockJobManager).getJobById(jobId, mockPortalUser);will(returnValue(mockJob));
+            allowing(mockJob).getUser();will(returnValue(userEmail));
+            allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
+            allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
+            allowing(mockJob).getId();will(returnValue(jobId));
+
+            oneOf(mockCloudComputeServices[0]).getConsoleLog(with(mockJob), with(any(Integer.class)));
+            will(returnValue(consoleData));
+        }});
+
+        ModelAndView mav = controller.getRawInstanceLogs(mockRequest, jobId, mockPortalUser);
+        Assert.assertTrue((Boolean)mav.getModel().get("success"));
+        Assert.assertEquals(consoleData, (String)mav.getModel().get("data"));
+    }
+
+    /**
+     * Tests getting instance logs fails with bad service ID
+     */
+    @Test
+    public void testGetRawInstanceLogs_BadService() throws Exception {
+        final String userEmail = "exampleuser@email.com";
+        final int jobId = 1234;
+        final VEGLJob mockJob = context.mock(VEGLJob.class);
+
+        context.checking(new Expectations() {{
+            allowing(mockPortalUser).getEmail();will(returnValue(userEmail));
+
+            oneOf(mockJobManager).getJobById(jobId, mockPortalUser);will(returnValue(mockJob));
+            allowing(mockJob).getUser();will(returnValue(userEmail));
+            allowing(mockJob).getComputeServiceId();will(returnValue("SERVICE-DNE"));
+            allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
+            allowing(mockJob).getId();will(returnValue(jobId));
+
+        }});
+
+        ModelAndView mav = controller.getRawInstanceLogs(mockRequest, jobId, mockPortalUser);
+        Assert.assertFalse((Boolean)mav.getModel().get("success"));
+    }
+
+    /**
+     * Tests requesting instance logs fails gracefully when the underlying service throws an exception
+     */
+    @Test
+    public void testGetRawInstanceLogs_UnableToRequest() throws Exception {
+        final String userEmail = "exampleuser@email.com";
+        final int jobId = 1234;
+        final VEGLJob mockJob = context.mock(VEGLJob.class);
+
+        context.checking(new Expectations() {{
+            allowing(mockPortalUser).getEmail();will(returnValue(userEmail));
+
+            oneOf(mockJobManager).getJobById(jobId, mockPortalUser);will(returnValue(mockJob));
+            allowing(mockJob).getUser();will(returnValue(userEmail));
+            allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
+            allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
+            allowing(mockJob).getId();will(returnValue(jobId));
+
+            oneOf(mockCloudComputeServices[0]).getConsoleLog(with(mockJob), with(any(Integer.class)));
+            will(throwException(new PortalServiceException("error")));
+        }});
+
+        ModelAndView mav = controller.getRawInstanceLogs(mockRequest, jobId, mockPortalUser);
+        Assert.assertFalse((Boolean)mav.getModel().get("success"));
     }
 }

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
@@ -1314,4 +1314,30 @@ public class TestJobListController extends PortalTestClass {
         ModelAndView mav = controller.getRawInstanceLogs(mockRequest, jobId, mockPortalUser);
         Assert.assertFalse((Boolean)mav.getModel().get("success"));
     }
+
+    /**
+     * Tests requesting instance logs fails gracefully when the underlying service returns null
+     */
+    @Test
+    public void testGetRawInstanceLogs_NullLogs() throws Exception {
+        final String userEmail = "exampleuser@email.com";
+        final int jobId = 1234;
+        final VEGLJob mockJob = context.mock(VEGLJob.class);
+
+        context.checking(new Expectations() {{
+            allowing(mockPortalUser).getEmail();will(returnValue(userEmail));
+
+            oneOf(mockJobManager).getJobById(jobId, mockPortalUser);will(returnValue(mockJob));
+            allowing(mockJob).getUser();will(returnValue(userEmail));
+            allowing(mockJob).getComputeServiceId();will(returnValue(computeServiceId));
+            allowing(mockJob).getStorageServiceId();will(returnValue(storageServiceId));
+            allowing(mockJob).getId();will(returnValue(jobId));
+
+            oneOf(mockCloudComputeServices[0]).getConsoleLog(with(mockJob), with(any(Integer.class)));
+            will(returnValue(null));
+        }});
+
+        ModelAndView mav = controller.getRawInstanceLogs(mockRequest, jobId, mockPortalUser);
+        Assert.assertFalse((Boolean)mav.getModel().get("success"));
+    }
 }


### PR DESCRIPTION
Added a new status log browser that allows a user to browse a job's status change history (via the audit log) and the raw console log directly from a running compute instance (if available).