### PR TITLE
VGL-181 template checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,22 +309,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.5.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.5.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.5.4</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/src/main/java/org/auscope/portal/server/web/controllers/ScriptBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/ScriptBuilderController.java
@@ -299,8 +299,7 @@ public class ScriptBuilderController extends BaseModelController {
             }
         }
         catch (PortalServiceException ex) {
-            logger.warn("Template code check failed: " + ex.getMessage());
-            logger.debug(ex);
+            logger.warn("Template code check failed: " + ex.getMessage(), ex);
             return generateJSONResponseMAV(false, null, "Template code check failed: " + ex.getMessage());
         }
 

--- a/src/main/java/org/auscope/portal/server/web/controllers/ScriptBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/ScriptBuilderController.java
@@ -21,8 +21,11 @@ import org.auscope.portal.core.util.FileIOUtil;
 import org.auscope.portal.server.vegl.VEGLJob;
 import org.auscope.portal.server.vegl.VEGLJobManager;
 import org.auscope.portal.server.web.security.ANVGLUser;
+import org.auscope.portal.server.web.service.LintResult;
 import org.auscope.portal.server.web.service.ScmEntryService;
 import org.auscope.portal.server.web.service.ScriptBuilderService;
+import org.auscope.portal.server.web.service.TemplateLintService;
+import org.auscope.portal.server.web.service.TemplateLintService.TemplateLanguage;
 import org.auscope.portal.server.web.service.scm.Problem;
 import org.auscope.portal.server.web.service.scm.Solution;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +57,9 @@ public class ScriptBuilderController extends BaseModelController {
     /** Handles SCM entries. */
     private ScmEntryService scmEntryService;
 
+    /** Script checking */
+    private TemplateLintService templateLintService;
+
     /**
      * Creates a new instance
      *
@@ -63,10 +69,12 @@ public class ScriptBuilderController extends BaseModelController {
     @Autowired
     public ScriptBuilderController(ScriptBuilderService sbService,
                                    VEGLJobManager jobManager,
-                                   ScmEntryService scmEntryService) {
+                                   ScmEntryService scmEntryService,
+                                   TemplateLintService templateLintService) {
         super(jobManager);
         this.sbService = sbService;
         this.scmEntryService = scmEntryService;
+        this.templateLintService = templateLintService;
     }
 
     /**
@@ -244,6 +252,59 @@ public class ScriptBuilderController extends BaseModelController {
         }
 
         return generateJSONResponseMAV(true, solutions, msg.toString());
+    }
+
+    /**
+     * Return a list of errors/warnings about a template.
+     *
+     * Passes the template string to pylint and turns the results into a list of
+     * error objects. Each entry contains a severity (error, warning etc),
+     * message string and the location in the code (from, to).
+     *
+     * The template language must be one of the following values:
+     * - python3
+     * - python2
+     *
+     * @param template String with template code
+     * @param lang String identifying template language (default=python3)
+     * @return List<LintResult> lint result objects
+     */
+    @RequestMapping("/lintTemplate.do")
+    public ModelAndView doLintTemplate(@RequestParam("template") String template,
+                                       @RequestParam(value="lang",
+                                                     required=false) String lang) {
+        TemplateLanguage templateLanguage = null;
+        String msg = "No errors or warnings found.";
+        List<LintResult> lints = null;
+
+        // Make sure it's a supported language
+        if (lang == null) {
+            templateLanguage = TemplateLanguage.PYTHON3;
+        }
+        else {
+            try {
+                templateLanguage = TemplateLanguage.valueOf(lang.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                logger.error("Invalid template language for template linting", ex);
+                return generateJSONResponseMAV(false, null, "Unable to check unsupported template language.");
+            }
+        }
+
+        // Get the linter to do its thing
+        try {
+            lints = templateLintService.checkTemplate(template, templateLanguage);
+            if (lints != null && lints.size() > 0) {
+                msg = String.format("Found {} issues", lints.size());
+            }
+        }
+        catch (PortalServiceException ex) {
+            logger.warn("Template code check failed: " + ex.getMessage());
+            logger.debug(ex);
+            return generateJSONResponseMAV(false, null, "Template code check failed: " + ex.getMessage());
+        }
+
+        return generateJSONResponseMAV(lints != null, lints, msg);
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/org/auscope/portal/server/web/service/LintResult.java
+++ b/src/main/java/org/auscope/portal/server/web/service/LintResult.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of the Virtual Geophysics Laboratory (VGL) project.
+ * Copyright (c) 2016, CSIRO
+ *
+ * Licensed under the terms of the GNU Lesser General Public License.
+ */
+package org.auscope.portal.server.web.service;
+
+import java.util.Arrays;
+
+/**
+ * A single result from the TemplateLintService
+ *
+ * Contains a short description of the issue, severity (error or warning) and
+ * the location in the code.
+ *
+ * Locations are captured as 2-element arrays, consisting of [line, column]
+ * (counting starts from 1 in each case). A result will always have a "from"
+ * location, but the "to" location is optional, only used if the issue covers a
+ * range in the document.
+ *
+ * @author Geoff Squire
+ *
+ */
+public class LintResult {
+
+    /**
+     * Enumerates possible severity of issues.
+     */
+    public static enum Severity {ERROR, WARNING}
+
+    public static final int LINE = 0;
+    public static final int COL = 1;
+
+    /**
+     * Description of the issue.
+     */
+    public String message;
+
+    /**
+     * Severity of the issue.
+     */
+    public Severity severity;
+
+    /**
+     * Location in the document where the issue begins.
+     *
+     */
+    public int[] from;
+
+    /**
+     * (optional) Location in the document where the issue ends.
+     */
+    public int[] to;
+
+    /**
+     * Create a new, empty instance.
+     */
+    public LintResult() {}
+
+    /**
+     * Create and initialise a new instance.
+     *
+     * @param severity Severity of the issue
+     * @param message String description of the issue
+     * @param from int[] start of the issue in the source [line, column]
+     * @param to int[] end of the issue in the source [line, column]
+     */
+    public LintResult(Severity severity, String message, int[] from, int[] to) {
+        this.severity = severity;
+        this.message = message;
+        this.from = Arrays.copyOf(from, 2);
+
+        if (to != null) {
+            this.to = Arrays.copyOf(to, 2);
+        }
+    }
+
+    /**
+     * Create and initialise a new instance.
+     *
+     * @param severity String severity of the issue
+     * @param message String description of the issue
+     * @param from int[] start of the issue in the source [line, column]
+     * @param to int[] end of the issue in the source [line, column]
+     */
+    public LintResult(String severity, String message, int[] from, int[] to) {
+        this(Severity.valueOf(severity.toUpperCase()), message, from, to);
+    }
+
+    /**
+     * Create and initialise a new instance with no to location specified.
+     *
+     * @param severity Severity of the issue
+     * @param message String description of the issue
+     * @param from int[] start of the issue in the source [line, column]
+     */
+    public LintResult(Severity severity, String message, int[] from) {
+        this(severity, message, from, null);
+    }
+
+    /**
+     * Create and initialise a new instance with no to location specified.
+     *
+     * @param severity String severity of the issue
+     * @param message String description of the issue
+     * @param from int[] start of the issue in the source [line, column]
+     */
+    public LintResult(String severity, String message, int[] from) {
+        this(Severity.valueOf(severity.toUpperCase()), message, from);
+    }
+}
+

--- a/src/main/java/org/auscope/portal/server/web/service/LintResult.java
+++ b/src/main/java/org/auscope/portal/server/web/service/LintResult.java
@@ -8,16 +8,17 @@ package org.auscope.portal.server.web.service;
 
 import java.util.Arrays;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * A single result from the TemplateLintService
  *
  * Contains a short description of the issue, severity (error or warning) and
  * the location in the code.
  *
- * Locations are captured as 2-element arrays, consisting of [line, column]
- * (counting starts from 1 in each case). A result will always have a "from"
- * location, but the "to" location is optional, only used if the issue covers a
- * range in the document.
+ * Locations are captured as Location instances with 0-based line and column
+ * numbers. A result will always have a "from" location, but the "to" location
+ * is optional, only used if the issue covers a range in the document.
  *
  * @author Geoff Squire
  *
@@ -27,10 +28,28 @@ public class LintResult {
     /**
      * Enumerates possible severity of issues.
      */
-    public static enum Severity {ERROR, WARNING}
+    public enum Severity {
+        @JsonProperty("error") ERROR,
+        @JsonProperty("warning") WARNING
+    }
 
-    public static final int LINE = 0;
-    public static final int COL = 1;
+    public static class Location {
+        int line;
+        int column;
+
+        public Location(int line, int column) {
+            this.line = line;
+            this.column = column;
+        }
+
+        public int getLine() {
+            return this.line;
+        }
+
+        public int getColumn() {
+            return this.column;
+        }
+    }
 
     /**
      * Description of the issue.
@@ -46,68 +65,47 @@ public class LintResult {
      * Location in the document where the issue begins.
      *
      */
-    public int[] from;
+    public Location from;
 
     /**
      * (optional) Location in the document where the issue ends.
      */
-    public int[] to;
+    public Location to;
 
     /**
      * Create a new, empty instance.
      */
-    public LintResult() {}
+    public LintResult() {
+        this.message = null;
+        this.severity = null;
+        this.from = null;
+        this.to = null;
+    }
 
     /**
      * Create and initialise a new instance.
      *
      * @param severity Severity of the issue
      * @param message String description of the issue
-     * @param from int[] start of the issue in the source [line, column]
-     * @param to int[] end of the issue in the source [line, column]
+     * @param from Location start of the issue in the source
+     * @param to Location end of the issue in the source
      */
-    public LintResult(Severity severity, String message, int[] from, int[] to) {
+    public LintResult(Severity severity, String message, Location from, Location to) {
         this.severity = severity;
         this.message = message;
-        this.from = Arrays.copyOf(from, 2);
-
-        if (to != null) {
-            this.to = Arrays.copyOf(to, 2);
-        }
+        this.from = from;
+        this.to = to;
     }
 
     /**
-     * Create and initialise a new instance.
-     *
-     * @param severity String severity of the issue
-     * @param message String description of the issue
-     * @param from int[] start of the issue in the source [line, column]
-     * @param to int[] end of the issue in the source [line, column]
-     */
-    public LintResult(String severity, String message, int[] from, int[] to) {
-        this(Severity.valueOf(severity.toUpperCase()), message, from, to);
-    }
-
-    /**
-     * Create and initialise a new instance with no to location specified.
+     * Create and initialise a new instance with no "to" Location specified.
      *
      * @param severity Severity of the issue
      * @param message String description of the issue
-     * @param from int[] start of the issue in the source [line, column]
+     * @param from Location start of the issue in the source
      */
-    public LintResult(Severity severity, String message, int[] from) {
+    public LintResult(Severity severity, String message, Location from) {
         this(severity, message, from, null);
-    }
-
-    /**
-     * Create and initialise a new instance with no to location specified.
-     *
-     * @param severity String severity of the issue
-     * @param message String description of the issue
-     * @param from int[] start of the issue in the source [line, column]
-     */
-    public LintResult(String severity, String message, int[] from) {
-        this(Severity.valueOf(severity.toUpperCase()), message, from);
     }
 }
 

--- a/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
@@ -57,7 +57,6 @@ public class TemplateLintService {
     /**
      * Create a new instance.
      */
-    @Autowired
     public TemplateLintService() {
         super();
     }

--- a/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
@@ -1,0 +1,200 @@
+/*
+
+import org.springframework.stereotype.Service;
+
+ * This file is part of the Virtual Geophysics Laboratory (VGL) project.
+ * Copyright (c) 2016, CSIRO
+ *
+ * Licensed under the terms of the GNU Lesser General Public License.
+ */
+package org.auscope.portal.server.web.service;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.aopalliance.reflect.Code;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mchange.v2.codegen.bean.CompleteConstructorGeneratorExtension;
+
+/**
+ * Checks a template script for errors or other issues.
+ *
+ * @author Geoff Squire
+ */
+@Service
+public class TemplateLintService {
+    private final Log logger = LogFactory.getLog(getClass());
+
+    /**
+     * Enumerate template languages we support.
+     */
+    public enum TemplateLanguage { PYTHON3, PYTHON2 }
+
+    /**
+     * Default time to wait for lint process to complete in seconds.
+     *
+     * TODO: Make this configurable.
+     */
+    public static final long DEFAULT_TIMEOUT = 5l;
+
+    /**
+     * Create a new instance.
+     */
+    @Autowired
+    public TemplateLintService() {
+        super();
+    }
+
+    /**
+     * Check a template script code and return any errors or other issues found.
+     *
+     * @param template String containing template code
+     * @param language TemplateLanguage language used for template
+     * @return List<LintResult> containing errors/issues found, if any
+     */
+    public List<LintResult> checkTemplate(String template, TemplateLanguage language)
+        throws PortalServiceException
+    {
+        List<LintResult> lints = null;
+
+        switch (language) {
+        case PYTHON3:
+            // fall through
+            // TODO: support py2/3 environments
+        case PYTHON2:
+            lints = pylint(template);
+            break;
+        default:
+            throw new PortalServiceException(String.format("Unsupported template language ({})",
+                                                           language));
+        }
+
+        return lints;
+    }
+
+    private List<LintResult> pylint(String template)
+        throws PortalServiceException
+    {
+        List<LintResult> lints = new ArrayList<LintResult>();
+
+        // Save template as a temporary python file
+        Path f;
+        try {
+            f = Files.createTempFile("contemplate", ".py");
+            BufferedWriter writer = Files.newBufferedWriter(f);
+            writer.write(template);
+            writer.close();
+        }
+        catch (Exception ex) {
+            throw new PortalServiceException("Failed to write template to temporary file.", ex);
+        }
+
+        // Run pylint in the temp file's directory
+        BufferedInputStream stdout;
+        try {
+            ProcessBuilder pb =
+            new ProcessBuilder("pylint", "-r", "n", f.getFileName().toString())
+            .directory(f.getParent().toFile());
+
+            Process p = pb.start();
+            stdout = new BufferedInputStream(p.getInputStream());
+            BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+            if (!p.waitFor(DEFAULT_TIMEOUT, TimeUnit.SECONDS)) {
+                // Timed out
+                throw new PortalServiceException(String.format("pylint process failed to complete before {} second timeout elapsed", DEFAULT_TIMEOUT));
+            }
+
+            // Finished successfully?
+            int rv = p.exitValue();
+            if (rv != 0) {
+                logger.debug("pylint stderr:");
+                String line = stderr.readLine();
+                while (line != null) {
+                    logger.debug(line);
+                    line = stderr.readLine();
+                }
+                throw new PortalServiceException(String.format("pylint process returned non-zero exit value: {}", rv));
+            }
+        }
+        catch (PortalServiceException pse) {
+            throw pse;
+        }
+        catch (Exception ex) {
+            throw new PortalServiceException("Failed to run pylint on template", ex);
+        }
+
+        // Parse results into LintResult objects
+        lints = parsePylintResults(stdout);
+
+        // Clean up
+        try {
+            Files.delete(f);
+        }
+        catch (Exception ex) {
+            throw new PortalServiceException("Failed to delete temporary template file.", ex);
+        }
+
+        return lints;
+    }
+
+    /**
+     * Parse pylint results into LintResult objects.
+     *
+     * @param input InputStream with results text
+     * @return List<LintResult> with issues
+     */
+    private List<LintResult> parsePylintResults(InputStream input)
+        throws PortalServiceException
+    {
+        List<LintResult> lints = new ArrayList<LintResult>();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = null;
+        try {
+            root = mapper.readTree(input);
+        }
+        catch (Exception ex) {
+            throw new PortalServiceException("Failed to parse pylint result json", ex);
+        }
+        if (root == null) {
+            throw new PortalServiceException("No JSON content found in pylint results");
+        }
+        else if (!root.isArray()) {
+            throw new PortalServiceException
+                (String.format("Unsupported pylint results: {}",
+                               root.toString()));
+        }
+
+        // Parsed json, so extract LintResult objects
+        for (JsonNode result: root) {
+            LintResult.Severity severity =
+                result.get("type").asText().equals("error")
+                ? LintResult.Severity.ERROR
+                : LintResult.Severity.WARNING;
+            lints.add(new LintResult(severity,
+                                     result.get("message").asText(),
+                                     new int[] {
+                                         result.get("line").asInt(),
+                                         result.get("column").asInt()
+                                     }));
+        }
+
+        return lints;
+    }
+}

--- a/src/main/webapp/WEB-INF/jsp/jobbuilder.jsp
+++ b/src/main/webapp/WEB-INF/jsp/jobbuilder.jsp
@@ -15,16 +15,21 @@
     </style>
 
     <%-- Code Mirror inclusions --%>
-    <link href="CodeMirror-5.16/lib/codemirror.css" type="text/css" rel="stylesheet" />    
+    <link href="CodeMirror-5.16/lib/codemirror.css" type="text/css" rel="stylesheet" />
+    <link href="CodeMirror-5.16/addon/lint/lint.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="CodeMirror-5.16/lib/codemirror.js"></script>
     <script type="text/javascript" src="CodeMirror-5.16/mode/python/python.js"></script>
     <script type="text/javascript" src="CodeMirror-5.16/mode/javascript/javascript.js"></script>
+    <script type="text/javascript" src="CodeMirror-5.16/addon/lint/lint.js"></script>
 
 
     <!-- Portal Core Includes -->    
     <jsp:include page="../../portal-core/jsimports.jsp"/>
     <jsp:include page="../../portal-core/cssimports.jsp"/>
     <jsp:include page="../../cssimports.htm"/>
+
+    <!-- Linters for templates -->
+    <script type="text/javascript" src="js/vegl/lint/pylint.js"></script>
 
     <!-- component includes -->
     <script type="text/javascript" src="js/vegl/widgets/CodeEditorField.js"></script>  
@@ -70,6 +75,7 @@
 
     <script type="text/javascript" src="js/vegl/JobBuilder.js"></script>
     <script type="text/javascript" src="js/vegl/HelpHandler.js"></script>
+
 </head>
 
 <body>

--- a/src/main/webapp/js/ScriptBuilder/ScriptBuilder.js
+++ b/src/main/webapp/js/ScriptBuilder/ScriptBuilder.js
@@ -68,7 +68,7 @@ Ext.define('ScriptBuilder.ScriptBuilder', {
             mode      : 'python',
             name      : 'scriptcodefield',
             readOnly  : true,
-            lint      : lintPython
+            lint      : { getAnnotations: lintPython, delay: 2000 }
         });
 
         var editorPanel =  Ext.create('Ext.form.FormPanel', {

--- a/src/main/webapp/js/ScriptBuilder/ScriptBuilder.js
+++ b/src/main/webapp/js/ScriptBuilder/ScriptBuilder.js
@@ -67,7 +67,8 @@ Ext.define('ScriptBuilder.ScriptBuilder', {
         this.editor = Ext.create('vegl.widgets.CodeEditorField',{
             mode      : 'python',
             name      : 'scriptcodefield',
-            readOnly  : true
+            readOnly  : true,
+            lint      : lintPython
         });
 
         var editorPanel =  Ext.create('Ext.form.FormPanel', {

--- a/src/main/webapp/js/vegl/lint/pylint.js
+++ b/src/main/webapp/js/vegl/lint/pylint.js
@@ -17,13 +17,16 @@ function lintPython(text, callback) {
                             var found = [], issue;
 
                             responseObj.data.forEach(function(it) {
-                                var from = CodeMirror.Pos(it.from[0], it.from[1]);
-                                var to = from;
+                                var from = CodeMirror.Pos(it.from.line, it.from.column);
+                                var to;
                                 if (it.to) {
-                                    to = CodeMirror.Pos(it.to[0], it.to[1]);
+                                    to = CodeMirror.Pos(it.to.line, it.to.column);
+                                }
+                                else {
+                                    to = CodeMirror.Pos(it.from.line, it.from.column + 1);
                                 }
                                 found.push({
-                                    severity: it.severity.toLowerCase(),
+                                    severity: it.severity,
                                     message: it.message,
                                     from: from,
                                     to: to

--- a/src/main/webapp/js/vegl/lint/pylint.js
+++ b/src/main/webapp/js/vegl/lint/pylint.js
@@ -1,0 +1,64 @@
+function lintPython(text, callback) {
+    // Don't check an empty string
+    if (Ext.isEmpty(text)) {
+        callback([]);
+    }
+    else {
+        // Send the text to the server to check
+        try {
+            Ext.Ajax.request({
+                url : 'lintTemplate.do',
+                params: { template: text },
+                callback : function(options, success, response) {
+                    var errorMsg, errorInfo;
+                    if (success) {
+                        var responseObj = Ext.JSON.decode(response.responseText);
+                        if (responseObj.success) {
+                            var found = [], issue;
+
+                            responseObj.data.forEach(function(it) {
+                                var from = CodeMirror.Pos(it.from[0], it.from[1]);
+                                var to = from;
+                                if (it.to) {
+                                    to = CodeMirror.Pos(it.to[0], it.to[1]);
+                                }
+                                found.push({
+                                    severity: it.severity.toLowerCase(),
+                                    message: it.message,
+                                    from: from,
+                                    to: to
+                                });
+                            });
+
+                            callback(found);
+                            return;
+                        } else {
+                            errorMsg = responseObj.msg;
+                            errorInfo = responseObj.debugInfo;
+                        }
+                    } else {
+                        errorMsg = "There was an error checking the template.";
+                        errorInfo = "Please try again in a few minutes or report this error to cg_admin@csiro.au.";
+                    }
+
+                    //Create an error object and pass it to custom error window
+                    var errorObj = {
+                        title : 'Script Checking Error',
+                        message : errorMsg,
+                        info : errorInfo
+                    };
+
+                    var errorWin = Ext.create('portal.widgets.window.ErrorWindow', {
+                        errorObj : errorObj
+                    });
+                    errorWin.show();
+                }
+            });
+        } catch (exception) {
+            console.log("Exception: ScriptBuilder template checking, details below - ");
+            console.log(exception);
+        }
+    }
+}
+
+lintPython.async = true;

--- a/src/main/webapp/js/vegl/widgets/CodeEditorField.js
+++ b/src/main/webapp/js/vegl/widgets/CodeEditorField.js
@@ -28,6 +28,10 @@ Ext.define('vegl.widgets.CodeEditorField', {
                         mode: config.mode
                     });
 
+                    if (config.lint) {
+                        this.editor.setOption('lint', config.lint);
+                    }
+
                     if (config.value) {
                         obj.setValue(config.value);
                     }

--- a/src/main/webapp/js/vegl/widgets/CodeEditorField.js
+++ b/src/main/webapp/js/vegl/widgets/CodeEditorField.js
@@ -25,12 +25,10 @@ Ext.define('vegl.widgets.CodeEditorField', {
                     this.editor = CodeMirror.fromTextArea(element,{
                         lineNumbers: true,
                         scrollbarStyle: 'null',
-                        mode: config.mode
+                        mode: config.mode,
+                        gutters: ["CodeMirror-lint-markers"],
+                        lint: config.lint || false
                     });
-
-                    if (config.lint) {
-                        this.editor.setOption('lint', config.lint);
-                    }
 
                     if (config.value) {
                         obj.setValue(config.value);

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestScriptBuilderController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestScriptBuilderController.java
@@ -13,6 +13,7 @@ import org.auscope.portal.server.vegl.VEGLJobManager;
 import org.auscope.portal.server.web.security.ANVGLUser;
 import org.auscope.portal.server.web.service.ScmEntryService;
 import org.auscope.portal.server.web.service.ScriptBuilderService;
+import org.auscope.portal.server.web.service.TemplateLintService;
 import org.jmock.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +27,7 @@ public class TestScriptBuilderController extends PortalTestClass {
     private ScriptBuilderController controller;
     private ScriptBuilderService mockSbService = context.mock(ScriptBuilderService.class);
     private ScmEntryService mockScmEntryService = context.mock(ScmEntryService.class);
+    private TemplateLintService mockTemplateLintService = context.mock(TemplateLintService.class);
     private VEGLJobManager mockJobManager = context.mock(VEGLJobManager.class);
     private VEGLJob mockJob = context.mock(VEGLJob.class);
 
@@ -35,7 +37,7 @@ public class TestScriptBuilderController extends PortalTestClass {
     @Before
     public void setup() {
         // Object Under Test
-        controller = new ScriptBuilderController(mockSbService, mockJobManager, mockScmEntryService);
+        controller = new ScriptBuilderController(mockSbService, mockJobManager, mockScmEntryService, mockTemplateLintService);
         user = new ANVGLUser();
         user.setId("456");
         user.setEmail("user@example.com");


### PR DESCRIPTION
Currently very verbose linting of the python template, including lots of convention and code smell checks. It also doesn't prevent you from continuing if it finds errors.

Requires pylint to be installed and available on the path for the webserver to execute.

N.B. Also includes an upgrade to jackson 2.8.5.