### PR TITLE
Better NCI job status checking. 

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNci.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNci.java
@@ -290,7 +290,8 @@ public class CloudComputeServiceNci extends CloudComputeService {
             session = sshCloudConnector.getSession(job);
             ExecResult res = sshCloudConnector.executeCommand(session, "qstat -s " + runningJobId);
             if (res.getExitStatus() != 0) {
-                if (res.getErr().contains("Job has finished")) {
+                String errMsg = res.getErr();
+                if (errMsg.contains("Job has finished") || errMsg.contains("Unknown Job Id")) {
                     return InstanceStatus.Missing;
                 }
                 throw new PortalServiceException("Could not query job status for job '"+job.getComputeInstanceId()+"': "+res.getErr());


### PR DESCRIPTION
Sometimes I think, for very old finished jobs, NCI will report that it can't find the job with that ID. Return MISSING now in this case.