### PR TITLE
Vgl 181 pylint

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
@@ -112,17 +112,9 @@ public class TemplateLintService {
         String errors;
         try {
             ProcessBuilder pb =
-                new ProcessBuilder("pylint", "-r", "n", "-f", "json",
-                                   "--disable=all",
-                                   "--enable=variables",
-                                   "--enable=stdlib",
-                                   "--enable=basic",
-                                   "--enable=iterable_check",
-                                   "--enable=format",
-                                   "--enable=typecheck",
-                                   "--enable=classes",
-                                   "--enable=string_constant",
-                                   "--enable=exceptions",
+                new ProcessBuilder("pylint",
+                                   "-r", "n",
+                                   "-f", "json",
                                    "--disable=R,C",
                                    f.getFileName().toString())
                 .directory(f.getParent().toFile());

--- a/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/TemplateLintService.java
@@ -113,6 +113,17 @@ public class TemplateLintService {
         try {
             ProcessBuilder pb =
                 new ProcessBuilder("pylint", "-r", "n", "-f", "json",
+                                   "--disable=all",
+                                   "--enable=variables",
+                                   "--enable=stdlib",
+                                   "--enable=basic",
+                                   "--enable=iterable_check",
+                                   "--enable=format",
+                                   "--enable=typecheck",
+                                   "--enable=classes",
+                                   "--enable=string_constant",
+                                   "--enable=exceptions",
+                                   "--disable=R,C",
                                    f.getFileName().toString())
                 .directory(f.getParent().toFile());
 


### PR DESCRIPTION
Tones down pylint checking so it ignores everything that's not a warning or error. Most usefully it ignores stylistic complaints, such as missing docstrings or trailing newlines.