### PR TITLE
Re-enabled multi select file downloads

### DIFF
--- a/src/main/webapp/js/vegl/widgets/JobDetailsPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobDetailsPanel.js
@@ -119,6 +119,9 @@ Ext.define('vegl.widgets.DetailsPanel', {
                     hideRowExpander: true,
                     hideLocationColumn: true,
                     nameColumnWidth: 150,
+                    selModel: {
+                        mode: 'MULTI'
+                    },
                     emptyText: '<p class="centeredlabel">This job doesn\'t have any uploaded input files or service downloads configured. Unsubmitted jobs will not have their input files visible here.</p>',
                     width: 350,
                     listeners: {

--- a/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
@@ -35,6 +35,7 @@ Ext.define('vegl.widgets.JobFilesPanel', {
 
         this.fileLookupUrl = !!config.cloudFiles ? 'secure/jobCloudFiles.do' : 'secure/stagedJobFiles.do';
         this.fileDownloadUrl = !!config.cloudFiles ? 'secure/downloadFile.do' : 'secure/downloadInputFile.do';
+        this.fileMultiDownloadUrl = !!config.cloudFiles ? 'secure/downloadAsZip.do' : null;
 
         this.fileGroupName = config.fileGroupName ? config.fileGroupName : 'Your Uploaded Files';
         this.remoteGroupName = config.remoteGroupName ? config.remoteGroupName : 'Remote Web Service Downloads';
@@ -50,14 +51,30 @@ Ext.define('vegl.widgets.JobFilesPanel', {
 
         //Action for downloading a single file
         this.downloadAction = new Ext.Action({
-            text: 'Download this file to your machine.',
+            text: 'Download file(s) to your machine.',
             disabled: true,
             iconCls: 'disk-icon',
             scope : this,
             handler: function() {
-                var item = jobFilesGrid.getSelectionModel().getSelection()[0];
-                var source = item.get('source');
-                if (source instanceof vegl.models.FileRecord) {
+                var items = jobFilesGrid.getSelectionModel().getSelection();
+                var downloadCount = 0;
+                var fileRecordCount = 0;
+
+                Ext.each(items, function(item) {
+                    var source = item.get('source');
+                    if (source instanceof vegl.models.FileRecord) {
+                        fileRecordCount++;
+                    } else if (source instanceof vegl.models.Download) {
+                        downloadCount++;
+                    }
+                });
+
+                if (downloadCount > 0 && fileRecordCount > 0) {
+                    portal.widgets.window.ErrorWindow.showText('Invalid Selection', 'Sorry, but combining multiple file categories isn\'t supported. Please only select files from the same category and try again.');
+                } else if (downloadCount > 1) {
+                    portal.widgets.window.ErrorWindow.showText('Invalid Selection', 'Sorry, you will need to download data service calls individually. Please only select a single data service download and try again.');
+                } else if (downloadCount == 0 && fileRecordCount == 1) {
+                    var source = items[0].get('source');
                     var params = {
                         jobId : this.currentJobId,
                         filename : source.get('name'),
@@ -65,8 +82,25 @@ Ext.define('vegl.widgets.JobFilesPanel', {
                     };
 
                     portal.util.FileDownloader.downloadFile(this.fileDownloadUrl, params);
-                } else if (source instanceof vegl.models.Download) {
+                } else if (downloadCount == 1 && fileRecordCount == 0) {
+                    var source = items[0].get('source');
                     portal.util.FileDownloader.downloadFile(source.get('url'));
+                } else if (fileRecordCount > 1) {
+                    if (!this.fileMultiDownloadUrl) {
+                        portal.widgets.window.ErrorWindow.showText('Invalid Selection', 'Sorry, but these files must be downloaded individually. Please select a single file and try again.');
+                        return;
+                    }
+
+                    var params = {
+                        jobId : this.currentJobId,
+                        files : []
+                    };
+
+                    Ext.each(items, function(item) {
+                        params.files.push(item.get('source').get('name'));
+                    });
+
+                    portal.util.FileDownloader.downloadFile(this.fileMultiDownloadUrl, params);
                 }
             }
         });


### PR DESCRIPTION
Re-enabled multi select file downloads for the job file panel. Explicitly blocks the user from combining download types for simplicity. We can always code in some (complicated) backend support if we want to remove this restriction.