### PR TITLE
Update JobFilesPanel.js

### DIFF
--- a/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
+++ b/src/main/webapp/js/vegl/widgets/JobFilesPanel.js
@@ -237,8 +237,7 @@ Ext.define('vegl.widgets.JobFilesPanel', {
                         jobId : this.currentJobId
                     },
                     scope : this,
-                    fileRecords : fileRecords,
-                    callback : Ext.bind(function(success, data, message, debugInfo, fileRecords) {
+                    callback : Ext.bind(function(success, data, message, debugInfo ) {
                         loadMask.hide();
                         if (!success) {
                             portal.widgets.window.ErrorWindow.showText('Error', 'Unable to request list of job downloads. Please try refreshing the page.', debugInfo);


### PR DESCRIPTION
Remove fileRecords parameter to the callback as the callback seems to infer the type of fileRecords incorrectly and the actual file data is lost. 

The callback is nested in another callback where fileRecords is in scope, so within the callback it is still available. 

This probably isn't a good fix, but fixes my problems.