### PR TITLE
Devl 86 - support for raijin jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
+                <configuration>
+                    <webApp>
+                        <contextPath>/VGL-Portal</contextPath>
+                    </webApp>
+                </configuration>
             </plugin>
             <!-- Powermock - Unit test work around... -->
             <plugin>
@@ -261,7 +266,7 @@
         <targetJdk>1.8</targetJdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.6.3</powermock.version>
-        <portal.core.version>2.0.0-SNAPSHOT</portal.core.version>
+        <portal.core.version>2.1.0-SNAPSHOT</portal.core.version>
         <httpclient.version>4.3.5</httpclient.version>
         <mysql.version>5.1.38</mysql.version>
         <jackson.version>2.9.0</jackson.version>
@@ -273,11 +278,11 @@
             <name>Open Source Geospatial Foundation Repository</name>
             <url>http://download.osgeo.org/webdav/geotools</url>
         </repository>
-        <repository>
-            <id>mygrid</id>
-            <name>MyGrid Repository</name>
-            <url>http://build.mygrid.org.uk/maven/repository/</url>
-        </repository>
+        <!-- <repository>
+             <id>mygrid</id>
+             <name>MyGrid Repository</name>
+             <url>http://build.mygrid.org.uk/maven/repository/</url>
+             </repository> -->
         <repository>
             <id>geotoolkit</id>
             <name>Geo Toolkit Repository</name>

--- a/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -427,24 +428,60 @@ public class ScmEntryService implements ScmLoader {
         if (jobId == null) {
             return null;
         }
+        
+        VEGLJob job = jobManager.getJobById(jobId, user);        
 
-        Map<String, Set<MachineImage>> images = new HashMap<>();
-        VEGLJob job = jobManager.getJobById(jobId, user);
+        return getJobImages(job, user);
+    }
+    
+    public Map<String, Set<MachineImage>> getJobImages(VEGLJob job, ANVGLUser user) throws PortalServiceException {
+        if (job == null) {
+            return null;
+        }               
 
-        for (Toolbox toolbox: getJobToolboxes(job)) {
-            for (Map<String, String> img: toolbox.getImages()) {
-                String providerId = img.get("provider");
-                Set<MachineImage> vms = images.get(providerId);
-                if (vms == null) {
-                    vms = new HashSet<>();
-                    images.put(providerId, vms);
+        return getJobImages(getJobSolutions(job), user);
+    }
+
+    public Map<String, Set<MachineImage>> getJobImages(Collection<String> solutionIds, ANVGLUser user) throws PortalServiceException {
+    	if (solutionIds == null) {
+    		return null;
+    	}
+    	
+    	Set<Solution> solutions = solutionIds.stream().map((String id) -> getScmSolution(id)).collect(Collectors.toSet());
+    	
+    	return getJobImages(solutions, user);
+    }
+    
+    /**
+     * Return a map from compute service ids to the set of images they can 
+     * provide for the solutions specified for the job.
+     *  
+     * @param solutions Set<Solution> solutions for the job in question
+     * @param user ANVGLUser currently logged in user
+     * @return Map<String, Set<MachineImage>> mapping from compute service id to set of image(s) they can provide
+     * @throws PortalServiceException
+     */
+    public Map<String, Set<MachineImage>> getJobImages(Set<Solution> solutions, 
+    												   ANVGLUser user) 
+    	throws PortalServiceException {
+    	Map<String, Set<MachineImage>> images = new HashMap<>();
+    	
+    	for (Solution solution: solutions) {
+            for (Toolbox toolbox: entryToolboxes(solution)) {
+                for (Map<String, String> img: toolbox.getImages()) {
+                    String providerId = img.get("provider");
+                    Set<MachineImage> vms = images.get(providerId);
+                    if (vms == null) {
+                        vms = new HashSet<>();
+                        images.put(providerId, vms);
+                    }
+                    MachineImage mi = new MachineImage(img.get("image_id"));
+                    mi.setName(toolbox.getName());
+                    mi.setDescription(toolbox.getDescription());
+                    vms.add(mi);
                 }
-                MachineImage mi = new MachineImage(img.get("image_id"));
-                mi.setName(toolbox.getName());
-                mi.setDescription(toolbox.getDescription());
-                vms.add(mi);
-            }
-        }
+            }    		
+    	}
 
         return images;
     }
@@ -457,10 +494,36 @@ public class ScmEntryService implements ScmLoader {
      */
     public Set<String> getJobProviders(Integer jobId, ANVGLUser user) throws PortalServiceException {
         Map<String, Set<MachineImage>> images = getJobImages(jobId, user);
-        if (images != null) {
-            return images.keySet();
-        }
-        return null;
+        return (images != null) ? images.keySet() : null;
+    }
+    
+    /**
+     * Return a set of compute service ids that can provide a toolbox suitable 
+     * for running a job comprising the specified solutions.
+     * 
+     * @param solutionIds Collection<String> of ids for the job's solutions 
+     * @param user ANVGLUser with the current logged in user
+     * @return Set<String> of compute service id strings
+     * @throws PortalServiceException
+     */
+    public Set<String> getJobProviders(Collection<String> solutionIds, ANVGLUser user)
+    	throws PortalServiceException {
+        Map<String, Set<MachineImage>> images = getJobImages(solutionIds, user);
+        return (images != null) ? images.keySet() : null;
+    }
+    
+    /**
+     * Return a set of compute servivce ids that can provide a toolbox 
+     * suitable for running a job comprising the specified solutions.
+     * 
+     * @param solutions Set<Solution> of solutions for the job in question
+     * @param user ANVGLUser currently logged in user
+     * @return Set<String> of compute service ids
+     * @throws PortalServiceException
+     */
+    public Set<String> getJobProviders(Set<Solution> solutions, ANVGLUser user) throws PortalServiceException {
+        Map<String, Set<MachineImage>> images = getJobImages(solutions, user);
+        return (images != null) ? images.keySet() : null;
     }
 
     /**

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
@@ -1084,7 +1084,7 @@ public class TestJobBuilderController {
     @Test
     public void testListImages() throws Exception {
         final String computeServiceId = "compute-service-id";
-        final VglMachineImage[] images = new VglMachineImage[] {context.mock(VglMachineImage.class)};
+        final VglMachineImage[] images = new VglMachineImage[] {context.mock(VglMachineImage.class)};        
 
         context.checking(new Expectations() {{
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeServiceId));
@@ -1094,11 +1094,11 @@ public class TestJobBuilderController {
             allowing(mockRequest).isUserInRole("testRole2");will(returnValue(true));
         }});
 
-        ModelAndView mav = controller.getImagesForComputeService(mockRequest, computeServiceId, null, new ANVGLUser());
+        ModelAndView mav = controller.getImagesForComputeService(mockRequest, computeServiceId, null, null, new ANVGLUser());
         Assert.assertNotNull(mav);
         Assert.assertTrue((Boolean)mav.getModel().get("success"));
         Assert.assertNotNull(mav.getModel().get("data"));
-        Assert.assertEquals(images.length, ((List) mav.getModel().get("data")).size());
+        Assert.assertEquals(images.length, ((Set) mav.getModel().get("data")).size());
     }
 
     /**
@@ -1110,7 +1110,7 @@ public class TestJobBuilderController {
     public void testListImages_NoRestrictions() throws Exception {
         final HashMap<String, Object> sessionVariables = new HashMap<String, Object>();
         final String computeServiceId = "compute-service-id";
-        final VglMachineImage[] images = new VglMachineImage[] {context.mock(VglMachineImage.class)};
+        final VglMachineImage[] images = new VglMachineImage[] {context.mock(VglMachineImage.class)};       
 
         sessionVariables.put("user-roles", new String[] {"testRole1", "testRole2"});
 
@@ -1124,11 +1124,11 @@ public class TestJobBuilderController {
             oneOf(images[0]).getPermissions();will(returnValue(null));
         }});
 
-        ModelAndView mav = controller.getImagesForComputeService(mockRequest, computeServiceId, null, new ANVGLUser());
+        ModelAndView mav = controller.getImagesForComputeService(mockRequest, computeServiceId, null, null, new ANVGLUser());
         Assert.assertNotNull(mav);
         Assert.assertTrue((Boolean)mav.getModel().get("success"));
         Assert.assertNotNull(mav.getModel().get("data"));
-        Assert.assertEquals(images.length, ((List) mav.getModel().get("data")).size());
+        Assert.assertEquals(images.length, ((Set) mav.getModel().get("data")).size());
     }
 
     /**
@@ -1661,7 +1661,7 @@ public class TestJobBuilderController {
         context.checking(new Expectations() {{
             allowing(mockCloudComputeServices[0]).getName();will(returnValue(name));
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(id));
-            allowing(mockScmEntryService).getJobProviders(null, user);will(returnValue(null));
+            allowing(mockScmEntryService).getJobProviders((Integer)null, user);will(returnValue(null));
             oneOf(mockNciDetailsDao).getByUser(mockPortalUser);will(returnValue(null));
         }});
 


### PR DESCRIPTION
To support Raijin jobs:
* Update JobBuilderController and ScmEntryService to support retrieving compute services, toolboxes and images that are valid for a job without requiring that the job object is created and saved first.
* Update to use portal-core 2.1.0-SNAPSHOT

Minor fixes:
* Use /VGL-Portal context path in jetty run to align dev with default deployment
* Remove mygrid repo since it stopped working and we don't seem to need it anymore