### PR TITLE
Include runcommand with machine image

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
@@ -478,6 +478,7 @@ public class ScmEntryService implements ScmLoader {
                     MachineImage mi = new MachineImage(img.get("image_id"));
                     mi.setName(toolbox.getName());
                     mi.setDescription(toolbox.getDescription());
+                    mi.setRunCommand(img.get("command"));
                     vms.add(mi);
                 }
             }    		


### PR DESCRIPTION
Hopefully final fix for DEVL-86. Now you can run a job that requires a run command on the toolbox (like escript).