### PR TITLE
Devl 90 duplicate downloads

### DIFF
--- a/src/main/java/org/auscope/portal/server/vegl/VEGLJobManager.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VEGLJobManager.java
@@ -22,6 +22,7 @@ public class VEGLJobManager {
     protected final Log logger = LogFactory.getLog(getClass());
 
     private VEGLJobDao veglJobDao;
+    private VglDownloadDao vglDownloadDao;
     private VEGLSeriesDao veglSeriesDao;
     private VGLJobAuditLogDao vglJobAuditLogDao;
     private NCIDetailsDao nciDetailsDao;
@@ -150,6 +151,38 @@ public class VEGLJobManager {
     public void setNciDetailsDao(NCIDetailsDao nciDetailsDao) {
         this.nciDetailsDao = nciDetailsDao;
     }
+    
+    /**
+     * Delete specified JobDownload objects associated with this VEGLJob. 
+     * 
+     * NB this does *not* save the job, you still need to call 
+     * VEGLJobManager.saveJob() on job after this.
+     * 
+     * @param job VEGLJob whose downloads to delete
+     * @param downloads List<VglDownload> of downloads to delete
+     */
+    public void deleteJobDownloads(VEGLJob job, List<VglDownload> downloads) {
+    	if (job != null && downloads != null) {
+    		int jobId = job.getId();
+    		for (VglDownload download: downloads) {
+    			if (download.getParent().getId() == jobId) {
+    				vglDownloadDao.deleteDownload(download);
+    			}
+    		}
+    	}
+    }
+    
+    /**
+     * Delete all downloads associated with job.
+     * 
+     * NB this does *not* save the job, you still need to call 
+     * VEGLJobManager.saveJob() on job after this.
+     * 
+     * @param job VEGLJob whose downloads will be deleted.
+     */
+    public void deleteJobDownloads(VEGLJob job) {    	
+    	this.deleteJobDownloads(job, job.getJobDownloads());
+    }
 
     private VEGLJob applyNCIDetails(VEGLJob job, NCIDetails nciDetails) {
         if (nciDetails != null) {
@@ -182,5 +215,13 @@ public class VEGLJobManager {
 
         return jobs;
     }
+
+	public VglDownloadDao getVglDownloadDao() {
+		return vglDownloadDao;
+	}
+
+	public void setVglDownloadDao(VglDownloadDao vglDownloadDao) {
+		this.vglDownloadDao = vglDownloadDao;
+	}   
 
 }

--- a/src/main/java/org/auscope/portal/server/vegl/VglDownloadDao.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VglDownloadDao.java
@@ -1,0 +1,24 @@
+/**
+ * 
+ */
+package org.auscope.portal.server.vegl;
+
+import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+
+/**
+ * @author Geoff Squire
+ *
+ */
+public class VglDownloadDao extends HibernateDaoSupport {
+
+	/**
+	 * Delete the specified VglDownload object.
+	 * 
+	 * @param download The VglDownload to delete
+	 */
+	public void deleteDownload(final VglDownload download) {
+		if (download != null) {
+			getHibernateTemplate().delete(download);
+		}
+	}
+}

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -679,12 +679,13 @@ public class JobBuilderController extends BaseCloudController {
         if (job == null) {
             return generateJSONResponseMAV(false);
         }
-
-        List<VglDownload> existingDownloads = job.getJobDownloads();
+        
         if (append) {
+        	List<VglDownload> existingDownloads = job.getJobDownloads();
             existingDownloads.addAll(parsedDownloads);
             job.setJobDownloads(existingDownloads);
         } else {
+        	jobManager.deleteJobDownloads(job);
             job.setJobDownloads(parsedDownloads);
         }
 

--- a/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/applicationContext.xml
@@ -332,12 +332,17 @@
 
     <bean id="veglJobManager" class="org.auscope.portal.server.vegl.VEGLJobManager">
         <property name="veglJobDao" ref="veglJobDao"/>
+        <property name="vglDownloadDao" ref="vglDownloadDao"/>
         <property name="veglSeriesDao" ref="veglSeriesDao"/>
         <property name="vglJobAuditLogDao" ref="vglJobAuditLogDao"/>
         <property name="nciDetailsDao" ref="nciDetailsDao"/>        
     </bean>
 
     <bean id="veglJobDao" class="org.auscope.portal.server.vegl.VEGLJobDao">
+        <property name="sessionFactory" ref="veglSessionFactory"/>
+    </bean>
+
+    <bean id="vglDownloadDao" class="org.auscope.portal.server.vegl.VglDownloadDao">
         <property name="sessionFactory" ref="veglSessionFactory"/>
     </bean>
 

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
@@ -1585,7 +1585,7 @@ public class TestJobBuilderController {
 
         context.checking(new Expectations() {{
             oneOf(mockJobManager).getJobById(Integer.parseInt(jobId), user);will(returnValue(job));
-
+            oneOf(mockJobManager).deleteJobDownloads(job);
             oneOf(mockJobManager).saveJob(job);
         }});
 


### PR DESCRIPTION
Fix for the duplicating job downloads. Now deletes existing job downloads from the database when replacing them with new ones.
