### PR TITLE
Google sign in scope change

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/security/ANVGLGoogleOAuth2ServiceProperties.java
+++ b/src/main/java/org/auscope/portal/server/web/security/ANVGLGoogleOAuth2ServiceProperties.java
@@ -1,0 +1,29 @@
+package org.auscope.portal.server.web.security;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.auscope.portal.core.server.security.oauth2.GoogleOAuth2ServiceProperties;
+
+/**
+ * ANVGLGoogleOAuth2ServiceProperties combines both the profile and email scopes
+ * so that the user information returned contains the user's name once again.
+ * 
+ * @author woo392
+ *
+ */
+public class ANVGLGoogleOAuth2ServiceProperties extends GoogleOAuth2ServiceProperties {
+
+	public ANVGLGoogleOAuth2ServiceProperties() {
+		super("", "", "");
+	}
+
+	public ANVGLGoogleOAuth2ServiceProperties(String clientId, String clientSecret, String redirectUri) {
+		super(clientId, clientSecret, redirectUri);
+		// Change the scope to both profile and email
+		Map<String, String> additionalAuthParams = new HashMap<>();
+		additionalAuthParams.put("scope",
+				"https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email");
+		this.setAdditionalAuthParams(additionalAuthParams);
+	}
+}

--- a/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -82,7 +82,7 @@
         </authentication-provider>
     </authentication-manager>
 
-    <beans:bean id="oauth2ServiceProperties" class="org.auscope.portal.core.server.security.oauth2.GoogleOAuth2ServiceProperties">
+    <beans:bean id="oauth2ServiceProperties" class="org.auscope.portal.server.web.security.ANVGLGoogleOAuth2ServiceProperties">
         <beans:constructor-arg name="redirectUri" value="${HOST.portalUrl}/oauth/callback"/>
         <beans:constructor-arg name="clientId" value="${env.oauth2.google.clientid}"/>
         <beans:constructor-arg name="clientSecret" value="${env.oauth2.google.clientsecret}"/>


### PR DESCRIPTION
Changed the Google sign in scope to combine both profile and email scopes so that the user's name would be returned with the user info once again. Should prevent Google login from crashing.