### PR TITLE
DEVL 131 - Too many redirects error on startup

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/security/DefaultEntryPoint.java
+++ b/src/main/java/org/auscope/portal/server/web/security/DefaultEntryPoint.java
@@ -21,7 +21,8 @@ public class DefaultEntryPoint extends BasicAuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
-        if(authException != null)
-            response.sendRedirect("login.html");
+    	if(authException != null) {
+    		response.setStatus(401);
+    	}
     }
 }

--- a/src/main/java/org/auscope/portal/server/web/security/RedirectUnconfiguredUserHandler.java
+++ b/src/main/java/org/auscope/portal/server/web/security/RedirectUnconfiguredUserHandler.java
@@ -63,39 +63,6 @@ public class RedirectUnconfiguredUserHandler implements AuthenticationSuccessHan
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication auth)
             throws IOException, ServletException {
-    	/*
-        Object principal = auth.getPrincipal();
-        DefaultSavedRequest savedRequest = (DefaultSavedRequest) request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST");
-
-        if (principal instanceof ANVGLUser) {
-            ANVGLUser user = (ANVGLUser) principal;
-            try {
-                boolean tcs = user.acceptedTermsConditionsStatus();
-                boolean configured = user.configuredServicesStatus(nciDetailsDao, cloudComputeServices);
-
-                //Redirect if the user needs to accept T&Cs OR if they don't have any config services setup
-                if (!configured || !tcs) {
-                    String params = "";
-                    String redirect = configured ? "../notcs.html" : "../noconfig.html";
-                    if (savedRequest != null) {
-                        URL requestUrl = new URL(savedRequest.getRequestURL());
-                        if (!requestUrl.getPath().contains("login.html")) {
-                            params = "?next=" + requestUrl.getPath();
-                        }
-                    }
-                    response.sendRedirect(redirect + params);
-                    return;
-                }
-            } catch (PortalServiceException e) {
-                log.error("Unable to verify if user is fully configured:", e);
-            }
-        }
-
-        if (savedRequest != null) {
-            response.sendRedirect(savedRequest.getRequestURL());
-            return;
-        }
-        */
         response.sendRedirect(frontEndUrl + "/login/loggedIn");
     }
 }


### PR DESCRIPTION
Fix "too many redirects" error when app loads up by not attempting to redirect to login when authorisation fails. Instead we catch the unauthorization error and send this response to the front-end to deal with.