### PR TITLE
Aus 3326 vgl offers aws compute provider even if solution does not support it

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -1167,12 +1167,11 @@ public class JobBuilderController extends BaseCloudController {
     	
     	ANVGLUser user = userService.getLoggedInUser();
         Set<String> jobCCSIds;
-        
-	    try {
-	    	jobCCSIds = scmEntryService.getJobProviders(jobId, user);
-	    } catch (AccessDeniedException e) {
-	        throw e;
-	    }
+        try {
+        	jobCCSIds = scmEntryService.getJobProviders(jobId, user);
+        } catch (AccessDeniedException e) {
+            throw e;
+        }
 
         Set<String> configuredServiceIds = new HashSet<String>();
         getConfiguredComputeServices(user, nciDetailsService).stream().forEach(x -> configuredServiceIds.add(x.getId()));

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -1163,17 +1163,16 @@ public class JobBuilderController extends BaseCloudController {
      * @throws PortalServiceException
      */
     @RequestMapping("/secure/getComputeServices.do")
-    public ModelAndView getComputeServices(@RequestParam(value="jobId",
-    required=false) final
-            Integer jobId/*,
-            @AuthenticationPrincipal ANVGLUser user*/) throws PortalServiceException {
+    public ModelAndView getComputeServices(@RequestParam(value="jobId", required=false) final Integer jobId) throws PortalServiceException {
+    	
     	ANVGLUser user = userService.getLoggedInUser();
         Set<String> jobCCSIds;
-		    try {
-            jobCCSIds = scmEntryService.getJobProviders(jobId, user);
-		    } catch (AccessDeniedException e) {
-		        throw e;
-		    }
+        
+	    try {
+	    	jobCCSIds = scmEntryService.getJobProviders(jobId, user);
+	    } catch (AccessDeniedException e) {
+	        throw e;
+	    }
 
         Set<String> configuredServiceIds = new HashSet<String>();
         getConfiguredComputeServices(user, nciDetailsService).stream().forEach(x -> configuredServiceIds.add(x.getId()));

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -1096,7 +1096,16 @@ public class JobBuilderController extends BaseCloudController {
                 imageProviders = scmEntryService.getJobImages(job, user);
             }            
 
-            Set<MachineImage> images = (imageProviders != null) ? imageProviders.get(computeServiceId) : new HashSet<MachineImage>();
+            Set<MachineImage> images = null;
+            
+            if (imageProviders != null) {
+            	images = imageProviders.get(computeServiceId);
+            }
+            
+            if(images == null) {
+            	 images= new HashSet<MachineImage>();
+            }
+            
             if (images.isEmpty()) {
                 // Fall back on old behaviour based on configured images for now
                 // Get images available to the current user
@@ -1160,11 +1169,11 @@ public class JobBuilderController extends BaseCloudController {
             @AuthenticationPrincipal ANVGLUser user*/) throws PortalServiceException {
     	ANVGLUser user = userService.getLoggedInUser();
         Set<String> jobCCSIds;
-        try {
+		    try {
             jobCCSIds = scmEntryService.getJobProviders(jobId, user);
-        } catch (AccessDeniedException e) {
-            throw e;
-        }
+		    } catch (AccessDeniedException e) {
+		        throw e;
+		    }
 
         Set<String> configuredServiceIds = new HashSet<String>();
         getConfiguredComputeServices(user, nciDetailsService).stream().forEach(x -> configuredServiceIds.add(x.getId()));
@@ -1254,6 +1263,54 @@ public class JobBuilderController extends BaseCloudController {
         allInputs.addAll(job.getJobDownloads());
 
         return generateJSONResponseMAV(true, allInputs, "");
+    }
+
+
+    /**
+     * Gets a JSON list of id/name pairs for every available compute service for the 
+     * given list of solution ids.
+     *
+     * Only those services that have images available for the solutions.
+     *
+     * Compute services that haven't been configured by the user will be ignored
+     * 
+     * @param solutions List of solution ids for which the available compute services is to be returned
+     *  
+     * @return List of compute services which have images for the given solutions
+     * 
+     * @throws PortalServiceException
+     */
+    @RequestMapping("/secure/getComputeServicesForSolutions.do")
+    public ModelAndView getComputeServicesForSolutions(@RequestParam(value="solutions", required=false) List<String> solutions) 
+    		throws PortalServiceException {
+    	ANVGLUser user = userService.getLoggedInUser();
+
+    	
+        Set<String> configuredServiceIds = new HashSet<String>();
+        getConfiguredComputeServices(user, nciDetailsService).stream().forEach(x -> configuredServiceIds.add(x.getId()));
+
+        List<ModelMap> simpleComputeServices = new ArrayList<>();
+    	
+		if (solutions!=null && !solutions.isEmpty()) {
+		    try {
+		    	Set<String> ccsIds = scmEntryService.getJobProviders(solutions);
+	    		if (ccsIds != null) {
+	    			for (CloudComputeService ccs : cloudComputeServices) {
+	    				// Add the ccs to the list if it's valid for job or we have no job
+	    				if (ccsIds.contains(ccs.getId()) && configuredServiceIds.contains(ccs.getId())) {
+	    					ModelMap map = new ModelMap();
+	    					map.put("id", ccs.getId());
+	    					map.put("name", ccs.getName());
+	    					simpleComputeServices.add(map);
+	    				}
+	    			}
+	    		}
+		    } catch (AccessDeniedException e) {
+		        throw e;
+		    }
+        }
+                
+        return generateJSONResponseMAV(true, simpleComputeServices, "");
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobBuilderController.java
@@ -1168,7 +1168,7 @@ public class JobBuilderController extends BaseCloudController {
     	ANVGLUser user = userService.getLoggedInUser();
         Set<String> jobCCSIds;
         try {
-        	jobCCSIds = scmEntryService.getJobProviders(jobId, user);
+            jobCCSIds = scmEntryService.getJobProviders(jobId, user);
         } catch (AccessDeniedException e) {
             throw e;
         }

--- a/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ScmEntryService.java
@@ -504,10 +504,38 @@ public class ScmEntryService implements ScmLoader {
      * @return Set<String> of compute service id strings
      * @throws PortalServiceException
      */
-    public Set<String> getJobProviders(Collection<String> solutionIds, ANVGLUser user)
+    public Set<String> getJobProviders(Collection<String> solutionIds)
     	throws PortalServiceException {
-        Map<String, Set<MachineImage>> images = getJobImages(solutionIds, user);
-        return (images != null) ? images.keySet() : null;
+    	
+    	Set<Solution> solutions = solutionIds.stream().map((String id) -> getScmSolution(id)).collect(Collectors.toSet());
+    	Set<Set<String>> providersForSolutions = new HashSet<Set<String>>();
+    	Set<String> result = null;
+    	
+    	for (Solution solution: solutions) {
+    		Set<String> providers = new HashSet<String>();
+    		if(result == null) {
+    			result = providers;
+    		} else {
+    			providersForSolutions.add(providers);
+    		}
+    		
+            for (Toolbox toolbox: entryToolboxes(solution)) {
+                for (Map<String, String> img: toolbox.getImages()) {
+                    String providerId = img.get("provider");
+                    providers.add(providerId);
+                }
+            }    		
+    	}
+
+    	if(result==null) {
+    		return null;
+    	}
+
+    	for (Set<String> providers : providersForSolutions) {
+			result.retainAll(providers);
+		}
+
+    	return result;
     }
     
     /**


### PR DESCRIPTION
Requires corresponding pull request in ngvl.

Fixes Aus 3326 and various other issues of the job wizard UI not updating correctly:

1) Added backend call `getComputeServicesForSolutions.do` to retrive the list of providers that can provide images for the given list of solutions
2) Fixed a potential NPE when `imageProviders.get(computeServiceId)` returns `null`
3) Fixed `getJobProviders(Collection<String> solutionIds, ANVGLUser user)` to return intersection of providers for the solutions rather than union. Previously if solution A only runs on Gadi and solution B only runs on AWS, both AWS and Gadi would be returned. No in this case empty result will be returned as there is no provider than can provide images for all solutions.