### PR TITLE
Use storageBaseKey from db for old jobs

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/service/cloud/CloudStorageServiceNci.java
+++ b/src/main/java/org/auscope/portal/server/web/service/cloud/CloudStorageServiceNci.java
@@ -50,7 +50,7 @@ public class CloudStorageServiceNci extends CloudStorageService {
      * @return
      */
     public String getWorkingJobDirectory(CloudFileOwner job) {
-        return String.format("/scratch/%1$s/vl-workingdir/%2$s", job.getProperty(NCIDetails.PROPERTY_NCI_PROJECT), generateBaseKey(job));
+        return String.format("/scratch/%1$s/vl-workingdir/%2$s", job.getProperty(NCIDetails.PROPERTY_NCI_PROJECT), jobToBaseKey(job));
     }
 
     /**
@@ -59,7 +59,7 @@ public class CloudStorageServiceNci extends CloudStorageService {
      * @return
      */
     public String getOutputJobDirectory(CloudFileOwner job) {
-        return String.format("/g/data/%1$s/vl-jobs/%2$s", job.getProperty(NCIDetails.PROPERTY_NCI_PROJECT), generateBaseKey(job));
+        return String.format("/g/data/%1$s/vl-jobs/%2$s", job.getProperty(NCIDetails.PROPERTY_NCI_PROJECT), jobToBaseKey(job));
     }
 
     private boolean jobFileExists(ChannelSftp c, String fullPath) throws PortalServiceException {


### PR DESCRIPTION
Applies fix from AUS-3274, using jobToBaseKey instead of generateBaseKey.

To test, run VGL and create a job on gadi, then restart VGL with a new hostname (e.g. in a new docker container) but using the same database. Previously you could see the old jobs but not access their files, now you should have full access as usual.